### PR TITLE
Fix add_event interface and OpenAI client

### DIFF
--- a/jarvis/agent.py
+++ b/jarvis/agent.py
@@ -127,7 +127,7 @@ class AICalendarAgent:
         message, tool_calls = await self.ai_client.chat(messages, self.tools)
 
         if tool_calls:
-            messages.append(message)
+            messages.append(message.model_dump())
             for call in tool_calls:
                 function_name = call.function.name
                 arguments = json.loads(call.function.arguments)

--- a/jarvis/ai_clients/openai_client.py
+++ b/jarvis/ai_clients/openai_client.py
@@ -16,11 +16,12 @@ class OpenAIClient(BaseAIClient):
         self.model = model
 
     async def chat(self, messages: List[Dict[str, Any]], tools: List[Dict[str, Any]]) -> Tuple[Any, Any]:
-        response = await self.client.chat.completions.create(
-            model=self.model,
-            messages=messages,
-            tools=tools,
-            tool_choice="auto",
-        )
+        params: Dict[str, Any] = {"model": self.model, "messages": messages}
+        if tools:
+            params["tools"] = tools
+            params["tool_choice"] = "auto"
+        else:
+            params["tool_choice"] = "none"
+        response = await self.client.chat.completions.create(**params)
         message = response.choices[0].message
         return message, message.tool_calls

--- a/jarvis/calendar_service.py
+++ b/jarvis/calendar_service.py
@@ -33,8 +33,9 @@ class CalendarService:
         today = date.today().strftime("%Y-%m-%d")
         return await self.get_events_by_date(today)
 
-    async def add_event(self, title: str, date_str: str, time: str, duration_minutes: int = 60, description: str = "") -> Dict[str, Any]:
-        datetime_str = f"{date_str} {time}"
+    async def add_event(self, title: str, date: str, time: str, duration_minutes: int = 60, description: str = "") -> Dict[str, Any]:
+        """Add an event on a given date and time."""
+        datetime_str = f"{date} {time}"
         data = {
             "title": title,
             "time": datetime_str,


### PR DESCRIPTION
## Summary
- update `CalendarService.add_event` to accept `date` parameter
- serialize assistant messages properly before reuse
- allow OpenAI client to omit tool settings when no tools are provided

## Testing
- `python -m py_compile jarvis/*.py main.py`
- `OPENAI_API_KEY=dummy python3 main.py` *(fails: 403 Forbidden from OpenAI)*

------
https://chatgpt.com/codex/tasks/task_e_6842080ccb54832ab5c597b7b62a555e