### PR TITLE
Add logger with SQLite storage

### DIFF
--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -2,6 +2,7 @@
 
 from .agent import AICalendarAgent
 from .calendar_service import CalendarService
+from .logger import JarvisLogger
 from .ai_clients import (
     AIClientFactory,
     BaseAIClient,
@@ -16,4 +17,5 @@ __all__ = [
     "BaseAIClient",
     "OpenAIClient",
     "AnthropicClient",
+    "JarvisLogger",
 ]

--- a/jarvis/logger.py
+++ b/jarvis/logger.py
@@ -1,0 +1,46 @@
+import logging
+import sqlite3
+from datetime import datetime
+from typing import Optional
+
+
+class JarvisLogger:
+    """Simple logger that writes to stdout and a SQLite database."""
+
+    def __init__(self, db_path: str = "jarvis_logs.db", log_level: int = logging.INFO) -> None:
+        self.db_path = db_path
+        self.conn = sqlite3.connect(self.db_path)
+        self._ensure_table()
+
+        self.logger = logging.getLogger("jarvis")
+        if not self.logger.handlers:
+            self.logger.setLevel(log_level)
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter("[%(asctime)s] %(levelname)s - %(message)s")
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+
+    def _ensure_table(self) -> None:
+        with self.conn:
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS logs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp TEXT,
+                    level TEXT,
+                    action TEXT,
+                    details TEXT
+                )
+                """
+            )
+
+    def log(self, level: str, action: str, details: Optional[str] = None) -> None:
+        level_name = level.upper()
+        message = f"{action}: {details}" if details else action
+        self.logger.log(getattr(logging, level_name, logging.INFO), message)
+        timestamp = datetime.utcnow().isoformat()
+        with self.conn:
+            self.conn.execute(
+                "INSERT INTO logs (timestamp, level, action, details) VALUES (?, ?, ?, ?)",
+                (timestamp, level_name, action, details or ""),
+            )

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from dotenv import load_dotenv  # Add this import
 from jarvis.ai_clients import AIClientFactory
 from jarvis.agent import AICalendarAgent
 from jarvis.calendar_service import CalendarService
+from jarvis.logger import JarvisLogger
 
 # Load environment variables from .env file
 load_dotenv()
@@ -14,8 +15,9 @@ load_dotenv()
 async def demo() -> None:
     api_key = os.getenv("OPENAI_API_KEY")  # Get the API key from environment
     ai_client = AIClientFactory.create("openai", api_key=api_key)
-    calendar_service = CalendarService()
-    agent = AICalendarAgent(ai_client, calendar_service)
+    logger = JarvisLogger()
+    calendar_service = CalendarService(logger=logger)
+    agent = AICalendarAgent(ai_client, calendar_service, logger=logger)
 
     # First create events
     # result = await agent.process_request_with_reasoning(
@@ -40,8 +42,9 @@ async def calendar_ai(command: str, api_key: Optional[str] = None) -> str:
     if api_key is None:
         api_key = os.getenv("OPENAI_API_KEY")  # Fallback to env if not provided
     ai_client = AIClientFactory.create("openai", api_key=api_key)
-    service = CalendarService()
-    agent = AICalendarAgent(ai_client, service)
+    logger = JarvisLogger()
+    service = CalendarService(logger=logger)
+    agent = AICalendarAgent(ai_client, service, logger=logger)
     response, _ = await agent.process_request(command)
     return response
 


### PR DESCRIPTION
## Summary
- add `JarvisLogger` for structured logging to stdout and SQLite
- log API calls and responses inside `CalendarService`
- log agent activity and tool calls in `AICalendarAgent`
- inject the logger into the demo and helper functions

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68420b36c734832aa8174e948ed548cc