### PR TITLE
Add FastAPI server and agent factory

### DIFF
--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -1,9 +1,11 @@
 """Jarvis calendar assistant package."""
 
 from .agent import AICalendarAgent
+from .main_agent import AIMainAgent
 from .calendar_service import CalendarService
 from .logger import JarvisLogger
 from .log_viewer import LogViewer
+from .agent_factory import AgentFactory
 from .ai_clients import (
     AIClientFactory,
     BaseAIClient,
@@ -20,4 +22,6 @@ __all__ = [
     "AnthropicClient",
     "JarvisLogger",
     "LogViewer",
+    "AgentFactory",
+    "AIMainAgent",
 ]

--- a/jarvis/agent_factory.py
+++ b/jarvis/agent_factory.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from .agent import AICalendarAgent
+from .main_agent import AIMainAgent
+from .calendar_service import CalendarService
+from .logger import JarvisLogger
+from .ai_clients import BaseAIClient
+
+
+class AgentFactory:
+    """Factory to create agent instances based on a type string."""
+
+    @staticmethod
+    def create(
+        agent_type: str,
+        ai_client: BaseAIClient,
+        logger: Optional[JarvisLogger] = None,
+    ) -> AICalendarAgent | AIMainAgent:
+        agent_type = agent_type.lower()
+        if agent_type in {"calendar", "calendar_agent", "aicalendaragent"}:
+            service = CalendarService(logger=logger)
+            return AICalendarAgent(ai_client, service, logger=logger)
+        if agent_type in {"jarvis", "main", "main_agent"}:
+            service = CalendarService(logger=logger)
+            calendar_agent = AICalendarAgent(ai_client, service, logger=logger)
+            return AIMainAgent(ai_client, {"calendar": calendar_agent}, logger=logger)
+        raise ValueError(f"Unsupported agent type: {agent_type}")

--- a/jarvis/main_agent.py
+++ b/jarvis/main_agent.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Tuple
+
+from .agent import AICalendarAgent
+from .ai_clients import BaseAIClient
+from .logger import JarvisLogger
+
+
+class AIMainAgent:
+    """Main Jarvis agent that delegates to specialized agents as tools."""
+
+    def __init__(
+        self,
+        ai_client: BaseAIClient,
+        agents: Dict[str, AICalendarAgent],
+        logger: JarvisLogger | None = None,
+    ) -> None:
+        self.ai_client = ai_client
+        self.agents = agents
+        self.logger = logger or JarvisLogger()
+
+        self.tools: List[Dict[str, Any]] = []
+        self._function_map: Dict[str, AICalendarAgent] = {}
+        for name, agent in agents.items():
+            func_name = f"{name}_command"
+            self.tools.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": func_name,
+                        "description": f"Delegate the command to the {name} agent",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"command": {"type": "string"}},
+                            "required": ["command"],
+                        },
+                    },
+                }
+            )
+            self._function_map[func_name] = agent
+
+        self.system_prompt = (
+            "You are Jarvis, the main assistant. "
+            "You can delegate specific tasks to specialized agents using the provided tools."
+        )
+
+    async def _execute_function(self, function_name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        agent = self._function_map.get(function_name)
+        if not agent:
+            return {"error": f"Unknown function: {function_name}"}
+        try:
+            command = arguments.get("command", "")
+            self.logger.log("INFO", f"Delegating to {function_name}", command)
+            response, _ = await agent.process_request(command)
+            return {"response": response}
+        except Exception as exc:
+            self.logger.log("ERROR", f"Error in {function_name}", str(exc))
+            return {"error": str(exc)}
+
+    async def process_request(self, user_input: str) -> Tuple[str, List[Dict[str, Any]]]:
+        messages = [
+            {"role": "system", "content": self.system_prompt},
+            {"role": "user", "content": user_input},
+        ]
+        actions_taken: List[Dict[str, Any]] = []
+
+        iterations = 0
+        MAX_ITERATIONS = 5
+        tool_calls = None
+        while iterations < MAX_ITERATIONS:
+            message, tool_calls = await self.ai_client.chat(messages, self.tools)
+            if not tool_calls:
+                break
+            messages.append(message.model_dump())
+            for call in tool_calls:
+                function_name = call.function.name
+                arguments = json.loads(call.function.arguments)
+                result = await self._execute_function(function_name, arguments)
+                actions_taken.append({"function": function_name, "arguments": arguments, "result": result})
+                messages.append({"role": "tool", "tool_call_id": call.id, "content": json.dumps(result)})
+            iterations += 1
+
+        if tool_calls:
+            message, _ = await self.ai_client.chat(messages, [])
+
+        return message.content if hasattr(message, "content") else str(message), actions_taken

--- a/server.py
+++ b/server.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from jarvis import AIClientFactory, AgentFactory, JarvisLogger
+
+app = FastAPI(title="Jarvis API")
+logger = JarvisLogger()
+
+
+class AgentRequest(BaseModel):
+    command: str
+    ai_provider: str = "openai"
+    api_key: Optional[str] = None
+
+
+@app.post("/calendar-agent")
+async def calendar_agent(req: AgentRequest):
+    """Execute a command using the calendar agent."""
+    try:
+        ai_client = AIClientFactory.create(req.ai_provider, api_key=req.api_key)
+        agent = AgentFactory.create("calendar", ai_client, logger=logger)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    response, actions = await agent.process_request(req.command)
+    return {"response": response, "actions": actions}
+
+
+@app.post("/jarvis")
+async def jarvis(req: AgentRequest):
+    """Execute a command using the main Jarvis agent."""
+    try:
+        ai_client = AIClientFactory.create(req.ai_provider, api_key=req.api_key)
+        agent = AgentFactory.create("jarvis", ai_client, logger=logger)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    response, actions = await agent.process_request(req.command)
+    return {"response": response, "actions": actions}
+
+
+def run():
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- introduce AgentFactory for strategy pattern
- expose a FastAPI `server.py` to run Jarvis agents via HTTP
- export `AgentFactory` from package
- add AIMainAgent to coordinate other agents
- add dedicated endpoints `/calendar-agent` and `/jarvis`

## Testing
- `python -m py_compile $(git ls-files '*.py') server.py`

------
https://chatgpt.com/codex/tasks/task_e_6842106d694c832a8cd7ae8f51f3e441