### PR TITLE
Fix config to read API key from env

### DIFF
--- a/jarvis/main_network.py
+++ b/jarvis/main_network.py
@@ -1,6 +1,8 @@
 # jarvis/main_network.py
 import asyncio
+import os
 from typing import Dict, Any
+from dotenv import load_dotenv
 
 from .network.core import AgentNetwork
 from .network.agents.calendary_agent import CollaborativeCalendarAgent
@@ -72,9 +74,10 @@ async def demo():
     """Demo of the collaborative Jarvis system"""
 
     # Configuration
+    load_dotenv()
     config = {
         "ai_provider": "openai",
-        "api_key": "your-api-key",  # Or use environment variable
+        "api_key": os.getenv("OPENAI_API_KEY"),
         "calendar_api_url": "http://localhost:8080",
     }
 
@@ -116,6 +119,9 @@ async def demo():
 # Simple interface for your existing code
 async def create_collaborative_jarvis(api_key: str = None):
     """Create a collaborative Jarvis instance"""
+    if api_key is None:
+        load_dotenv()
+        api_key = os.getenv("OPENAI_API_KEY")
     config = {
         "ai_provider": "openai",
         "api_key": api_key,


### PR DESCRIPTION
## Summary
- use `load_dotenv` and `os.getenv` to load the API key in `main_network` demo
- allow `create_collaborative_jarvis` to fall back to `OPENAI_API_KEY`

## Testing
- `OPENAI_API_KEY=dummy python -m jarvis.main_network` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68421bfd4ca4832a884d217502e7ac58