### PR TITLE
Improve UTC handling for calendar dates

### DIFF
--- a/jarvis/agent.py
+++ b/jarvis/agent.py
@@ -101,7 +101,8 @@ class AICalendarAgent:
             "2. Breaking down complex tasks into calendar API calls\n"
             "3. Executing the necessary operations in the correct order\n"
             "4. Explaining the results plainly\n\n"
-            "Current date: {current_date}"
+            "Current date (UTC): {current_date}. Always interpret dates "
+            "relative to this value."
         )
 
         self._function_map = {
@@ -127,7 +128,7 @@ class AICalendarAgent:
             return error
 
     async def process_request(self, user_input: str) -> Tuple[str, List[Dict[str, Any]]]:
-        current_date = date.today().strftime("%Y-%m-%d")
+        current_date = self.calendar_service.current_date_utc()
         messages = [
             {"role": "system", "content": self.system_prompt.format(current_date=current_date)},
             {"role": "user", "content": user_input},

--- a/jarvis/calendar_service.py
+++ b/jarvis/calendar_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import aiohttp
-from datetime import date
+from datetime import date, datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from .logger import JarvisLogger
@@ -13,6 +13,10 @@ class CalendarService:
     def __init__(self, base_url: str = "http://localhost:8080", logger: JarvisLogger | None = None) -> None:
         self.base_url = base_url
         self.logger = logger or JarvisLogger()
+
+    def current_date_utc(self) -> str:
+        """Return the current date in UTC as YYYY-MM-DD."""
+        return datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
     async def _request(
         self, method: str, endpoint: str, data: Optional[Dict[str, Any]] = None
@@ -78,7 +82,7 @@ class CalendarService:
 
     async def get_today_events(self) -> Dict[str, Any]:
         """Get today's events - returns dict instead of list"""
-        today = date.today().strftime("%Y-%m-%d")
+        today = self.current_date_utc()
         return await self.get_events_by_date(today)
 
     async def add_event(

--- a/jarvis/network/agents/ui_agent.py
+++ b/jarvis/network/agents/ui_agent.py
@@ -2,7 +2,7 @@
 import asyncio
 import json
 from typing import Any, Dict, Set, List, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 import uuid
 
 from ..core import NetworkAgent, Message
@@ -80,7 +80,7 @@ class UIAgent(NetworkAgent):
         # Store request
         self.pending_requests[request_id] = {
             "user_input": user_input,
-            "start_time": datetime.now(),
+            "start_time": datetime.now(timezone.utc),
             "capability_requests": {},
             "responses": {},
             "status": "processing",
@@ -91,7 +91,7 @@ class UIAgent(NetworkAgent):
             {
                 "role": "user",
                 "content": user_input,
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
             }
         )
 
@@ -139,9 +139,14 @@ class UIAgent(NetworkAgent):
         # Create a system prompt that knows about available capabilities
         available_capabilities = []
         for cap, agents in self.network.capability_registry.items():
-            available_capabilities.append(f"- {cap}: provided by {', '.join(agents)}")
+            available_capabilities.append(
+                f"- {cap}: provided by {', '.join(agents)}"
+            )
 
+        current_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         system_prompt = f"""You are JARVIS, analyzing user requests to determine which capabilities are needed.
+
+Current date (UTC): {current_date}
 
 Available capabilities:
 {chr(10).join(available_capabilities)}
@@ -227,7 +232,7 @@ Be thorough - include all capabilities that might be needed."""
         context = {
             "user_request": request_data["user_input"],
             "agent_responses": responses,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
         system_prompt = """You are JARVIS, Tony Stark's AI assistant. 

--- a/jarvis/network/core.py
+++ b/jarvis/network/core.py
@@ -5,7 +5,7 @@ import asyncio
 import uuid
 from typing import Any, Dict, List, Optional, Set, Callable
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 from ..logger import JarvisLogger
 
@@ -20,7 +20,7 @@ class Message:
     message_type: str = ""
     content: Any = None
     request_id: str = ""
-    timestamp: datetime = field(default_factory=datetime.now)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     reply_to: Optional[str] = None  # For response tracking
 
 


### PR DESCRIPTION
## Summary
- use a helper in `CalendarService` to provide the current UTC date
- insert the UTC date into the calendar agent system prompt
- default to UTC when network agents process requests
- include UTC context when analysing user requests
- track message timestamps in UTC

## Testing
- `python -m jarvis.main_network` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68421e763054832a95026694b7ef04c9