### PR TITLE
Integrate natural language calendar commands

### DIFF
--- a/jarvis/main_network.py
+++ b/jarvis/main_network.py
@@ -33,11 +33,11 @@ class JarvisSystem:
         self.ui_agent = UIAgent(ai_client, self.logger)
         self.network.register_agent(self.ui_agent)
 
-        # Create Calendar Agent
+        # Create Calendar Agent with integrated natural language logic
         calendar_service = CalendarService(
             self.config.get("calendar_api_url", "http://localhost:8080")
         )
-        calendar_agent = CollaborativeCalendarAgent(calendar_service, self.logger)
+        calendar_agent = CollaborativeCalendarAgent(ai_client, calendar_service, self.logger)
         self.network.register_agent(calendar_agent)
 
         # Add more agents as you build them:

--- a/jarvis/network/agents/calendary_agent.py
+++ b/jarvis/network/agents/calendary_agent.py
@@ -7,6 +7,7 @@ import uuid
 from ..base_agent import NetworkAgent
 from ..message import Message
 from ...calendar_service import CalendarService
+from ...ai_clients import BaseAIClient
 from ...logger import JarvisLogger
 
 
@@ -14,10 +15,111 @@ class CollaborativeCalendarAgent(NetworkAgent):
     """Calendar agent that collaborates with other agents"""
 
     def __init__(
-        self, calendar_service: CalendarService, logger: JarvisLogger | None = None
+        self,
+        ai_client: BaseAIClient,
+        calendar_service: CalendarService,
+        logger: JarvisLogger | None = None,
     ):
         super().__init__("CalendarAgent", logger)
         self.calendar_service = calendar_service
+        self.ai_client = ai_client
+
+        # Tools and prompt for natural language commands
+        self.tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_today_events",
+                    "description": "Get all events scheduled for today",
+                    "parameters": {"type": "object", "properties": {}, "required": []},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_events_by_date",
+                    "description": "Get all events for a specific date",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "date": {
+                                "type": "string",
+                                "description": "Date in YYYY-MM-DD format",
+                            }
+                        },
+                        "required": ["date"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "add_event",
+                    "description": "Add a new event to the calendar",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string"},
+                            "date": {
+                                "type": "string",
+                                "description": "Date in YYYY-MM-DD format",
+                            },
+                            "time": {
+                                "type": "string",
+                                "description": "Time in HH:MM format",
+                            },
+                            "duration_minutes": {"type": "integer", "default": 60},
+                            "description": {"type": "string", "default": ""},
+                        },
+                        "required": ["title", "date", "time"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "delete_event",
+                    "description": "Delete an event by its ID",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"event_id": {"type": "string"}},
+                        "required": ["event_id"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "analyze_schedule",
+                    "description": "Analyze schedule patterns and provide insights",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"date_range": {"type": "string", "default": "today"}},
+                        "required": [],
+                    },
+                },
+            },
+        ]
+
+        self.system_prompt = (
+            "You are Jarvis, the AI assistant from Iron Man. "
+            "Your user is Owen Stepan taking on the role of Tony Stark. "
+            "Respond in a clear, conversational style without using asterisks or "
+            "other non-textual formatting. You help manage the user's schedule by:\n"
+            "1. Understanding natural language requests\n"
+            "2. Breaking down complex tasks into calendar API calls\n"
+            "3. Executing the necessary operations in the correct order\n"
+            "4. Explaining the results plainly\n\n"
+            "Current date (UTC): {current_date}. Always interpret dates relative to this value."
+        )
+
+        self._function_map = {
+            "get_today_events": self.calendar_service.get_today_events,
+            "get_events_by_date": self.calendar_service.get_events_by_date,
+            "add_event": self.calendar_service.add_event,
+            "delete_event": self.calendar_service.delete_event,
+            "analyze_schedule": self.calendar_service.analyze_schedule,
+        }
 
         # Register additional handlers
         self.message_handlers["schedule_update"] = self._handle_schedule_update
@@ -47,6 +149,7 @@ class CollaborativeCalendarAgent(NetworkAgent):
             "find_free_time",
             "check_availability",
             "schedule_optimization",
+            "calendar_command",
         }
 
     @property
@@ -57,6 +160,60 @@ class CollaborativeCalendarAgent(NetworkAgent):
             "get_weather",  # From weather agent for outdoor events
             "get_traffic",  # From maps agent for travel time
         }
+
+    async def _execute_function(self, function_name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        func = self._function_map.get(function_name)
+        if not func:
+            return {"error": f"Unknown function: {function_name}"}
+        try:
+            self.logger.log("INFO", f"Calling {function_name}", json.dumps(arguments))
+            result = await func(**arguments)
+            self.logger.log("INFO", f"Result {function_name}", json.dumps(result))
+            return result
+        except Exception as exc:
+            error = {"error": str(exc)}
+            self.logger.log("ERROR", f"Error {function_name}", json.dumps(error))
+            return error
+
+    async def _process_calendar_command(self, command: str) -> Dict[str, Any]:
+        """Process a natural language calendar command using AI."""
+        current_date = self.calendar_service.current_date_utc()
+        messages = [
+            {"role": "system", "content": self.system_prompt.format(current_date=current_date)},
+            {"role": "user", "content": command},
+        ]
+        actions_taken: List[Dict[str, Any]] = []
+
+        iterations = 0
+        MAX_ITERATIONS = 5
+        tool_calls = None
+        while iterations < MAX_ITERATIONS:
+            message, tool_calls = await self.ai_client.chat(messages, self.tools)
+            self.logger.log("INFO", "AI response", getattr(message, "content", str(message)))
+
+            if not tool_calls:
+                break
+
+            messages.append(message.model_dump())
+            for call in tool_calls:
+                function_name = call.function.name
+                arguments = json.loads(call.function.arguments)
+                self.logger.log("INFO", "Tool call", function_name)
+                result = await self._execute_function(function_name, arguments)
+                actions_taken.append({"function": function_name, "arguments": arguments, "result": result})
+                messages.append({"role": "tool", "tool_call_id": call.id, "content": json.dumps(result)})
+
+            iterations += 1
+
+        if iterations >= MAX_ITERATIONS:
+            self.logger.log("ERROR", "Max iterations reached", str(iterations))
+
+        if tool_calls:
+            message, _ = await self.ai_client.chat(messages, [])
+
+        response_text = message.content if hasattr(message, "content") else str(message)
+
+        return {"response": response_text, "actions": actions_taken}
 
     async def _handle_capability_request(self, message: Message) -> None:
         """Handle incoming capability requests"""
@@ -156,6 +313,13 @@ class CollaborativeCalendarAgent(NetworkAgent):
 
                 # Optimize
                 result = self._optimize_schedule(events, goals)
+
+            elif capability == "calendar_command":
+                command = data.get("command")
+                if not isinstance(command, str):
+                    await self.send_error(message.from_agent, "Invalid command", message.request_id)
+                    return
+                result = await self._process_calendar_command(command)
 
             if result:
                 await self.send_capability_response(

--- a/jarvis/network/agents/ui_agent.py
+++ b/jarvis/network/agents/ui_agent.py
@@ -283,14 +283,8 @@ Be concise but complete. Don't mention the internal agent names."""
             word in lower_input
             for word in ["schedule", "calendar", "meeting", "appointment"]
         ):
-            if "add" in lower_input or "schedule" in lower_input:
-                capabilities_needed.append("add_event")
-            elif (
-                "check" in lower_input or "show" in lower_input or "what" in lower_input
-            ):
-                capabilities_needed.append("view_schedule")
-            elif "cancel" in lower_input or "remove" in lower_input:
-                capabilities_needed.append("remove_event")
+            capabilities_needed.append("calendar_command")
+            parameters["calendar_command"] = {"command": user_input}
 
         # Email-related
         if any(word in lower_input for word in ["email", "mail", "send"]):


### PR DESCRIPTION
## Summary
- extend `CollaborativeCalendarAgent` to understand free‑form calendar commands
- drop `LegacyCalendarAgent` wrapper
- update agent registry and imports
- adjust `JarvisSystem` to instantiate the updated calendar agent
- route simple UI requests to the new `calendar_command` capability

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684225f60d4c832a93ef0f47efe8480b