### PR TITLE
Configurable UIAgent response timeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,10 @@ python -m asyncio run main.py
 - `OPENAI_API_KEY` – key for OpenAI based clients.
 - `ANTHROPIC_API_KEY` – key for Anthropic based clients.
 
+## JarvisSystem options
+- `response_timeout` – number of seconds the `UIAgent` waits for capability
+  responses when processing a user request. Defaults to 10 seconds.
+
 ## Logs
 Logs are stored in `jarvis_logs.db`. Use the log viewer:
 ```bash

--- a/jarvis/main_network.py
+++ b/jarvis/main_network.py
@@ -30,7 +30,8 @@ class JarvisSystem:
         )
 
         # Create UI Agent (main interface)
-        self.ui_agent = UIAgent(ai_client, self.logger)
+        ui_timeout = self.config.get("response_timeout", 10.0)
+        self.ui_agent = UIAgent(ai_client, self.logger, response_timeout=ui_timeout)
         self.network.register_agent(self.ui_agent)
 
         # Create Calendar Agent with integrated natural language logic

--- a/jarvis/network/agents/ui_agent.py
+++ b/jarvis/network/agents/ui_agent.py
@@ -14,9 +14,15 @@ from ...logger import JarvisLogger
 class UIAgent(NetworkAgent):
     """Agent that handles user interaction and coordinates complex requests"""
 
-    def __init__(self, ai_client: BaseAIClient, logger: Optional[JarvisLogger] = None):
+    def __init__(
+        self,
+        ai_client: BaseAIClient,
+        logger: Optional[JarvisLogger] = None,
+        response_timeout: float = 10.0,
+    ):
         super().__init__("UIAgent", logger)
         self.ai_client = ai_client
+        self.response_timeout = response_timeout
         self.pending_requests: Dict[str, Dict[str, Any]] = {}
         self.conversation_history: List[Dict[str, Any]] = []
 
@@ -104,7 +110,9 @@ class UIAgent(NetworkAgent):
             await self._execute_capability_requests(request_id, analysis)
 
             # Wait for responses (with timeout)
-            response = await self._wait_for_responses(request_id, timeout=10.0)
+            response = await self._wait_for_responses(
+                request_id, timeout=self.response_timeout
+            )
 
             # Format final response
             final_response = await self._format_response(request_id, response)


### PR DESCRIPTION
## Summary
- make `UIAgent` response timeout configurable via new `response_timeout` parameter
- propagate the timeout from `JarvisSystem` config
- document the option in `AGENTS.md`

## Testing
- `python -m py_compile jarvis/network/agents/ui_agent.py jarvis/main_network.py`

------
https://chatgpt.com/codex/tasks/task_e_68422e768080832a8859f5a941f98836