### PR TITLE
Fix pending task tracking in calendar agent

### DIFF
--- a/jarvis/network/agents/calendary_agent.py
+++ b/jarvis/network/agents/calendary_agent.py
@@ -225,6 +225,17 @@ class CollaborativeCalendarAgent(NetworkAgent):
 
         self.logger.log("INFO", f"Handling {capability}", json.dumps(data))
 
+        # Track active request details so follow-up responses can be managed
+        self.active_tasks.setdefault(
+            message.request_id,
+            {
+                "data": data,
+                "original_requester": message.from_agent,
+                "original_message_id": message.id,
+                "responses": [],
+            },
+        )
+
         try:
             result = None
 


### PR DESCRIPTION
## Summary
- ensure CollaborativeCalendarAgent initializes `active_tasks` entries when handling a capability request

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- ran a demo invocation with dummy AI client

------
https://chatgpt.com/codex/tasks/task_e_684231a71574832abbed89d2bb5b94f1