### PR TITLE
Fix timezone parameter for demo script

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from typing import Optional
 from dotenv import load_dotenv
 
 from jarvis.main_network import create_collaborative_jarvis
+from tzlocal import get_localzone_name
 
 # Load environment variables from .env file
 load_dotenv()
@@ -12,7 +13,8 @@ load_dotenv()
 async def demo() -> None:
     jarvis = await create_collaborative_jarvis(os.getenv("OPENAI_API_KEY"))
     result = await jarvis.process_request(
-        "Remove everything from my schedule for June 5th."
+        "Remove everything from my schedule for June 5th.",
+        get_localzone_name(),
     )
     print(result)
     await jarvis.shutdown()
@@ -20,7 +22,7 @@ async def demo() -> None:
 
 async def calendar_ai(command: str, api_key: Optional[str] = None) -> str:
     jarvis = await create_collaborative_jarvis(api_key or os.getenv("OPENAI_API_KEY"))
-    result = await jarvis.process_request(command)
+    result = await jarvis.process_request(command, get_localzone_name())
     await jarvis.shutdown()
     return result["response"]
 


### PR DESCRIPTION
## Summary
- update demo helper to pass `get_localzone_name()`
- ensure helper API also supplies timezone

## Testing
- `pip install python-dotenv tzlocal aiohttp openai`
- `python3 main.py` *(fails: ModuleNotFoundError: No module named 'anthropic')*

------
https://chatgpt.com/codex/tasks/task_e_684235ee51a8832abfef91cdf47c783a