### PR TITLE
Improve calendar keyword detection

### DIFF
--- a/jarvis/agents/ui_agent.py
+++ b/jarvis/agents/ui_agent.py
@@ -325,7 +325,13 @@ Be concise but complete. Don't mention the internal agent names."""
         # Calendar-related
         if any(
             word in lower_input
-            for word in ["schedule", "calendar", "meeting", "appointment"]
+            for word in [
+                "schedule",
+                "calendar",
+                "meeting",
+                "appointment",
+                "event",
+            ]
         ):
             capabilities_needed.append("calendar_command")
             parameters["calendar_command"] = {"command": user_input}


### PR DESCRIPTION
## Summary
- update keyword list in `_simple_request_analysis` to include `event`

## Testing
- `python -m py_compile jarvis/agents/ui_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68423f231dac832aa1c7808297ee0a2d