### PR TITLE
Rename schedule analysis capability

### DIFF
--- a/jarvis/agents/calendar_agent.py
+++ b/jarvis/agents/calendar_agent.py
@@ -96,8 +96,8 @@ class CollaborativeCalendarAgent(NetworkAgent):
             {
                 "type": "function",
                 "function": {
-                    "name": "analyze_schedule",
-                    "description": "Analyze schedule patterns and provide insights",
+                    "name": "get_schedule_summary",
+                    "description": "Get a helpful summary of today's schedule",
                     "parameters": {
                         "type": "object",
                         "properties": {
@@ -126,7 +126,7 @@ class CollaborativeCalendarAgent(NetworkAgent):
             "get_events_by_date": self.calendar_service.get_events_by_date,
             "add_event": self.calendar_service.add_event,
             "delete_event": self.calendar_service.delete_event,
-            "analyze_schedule": self.calendar_service.analyze_schedule,
+            "get_schedule_summary": self.calendar_service.get_schedule_summary,
         }
 
         # Register additional handlers
@@ -156,7 +156,7 @@ class CollaborativeCalendarAgent(NetworkAgent):
             "view_schedule",
             "add_event",
             "remove_event",
-            "analyze_schedule",
+            "get_schedule_summary",
         }
 
     @property
@@ -260,9 +260,9 @@ class CollaborativeCalendarAgent(NetworkAgent):
                     return
                 result = await self.calendar_service.delete_event(event_id)
 
-            elif capability == "analyze_schedule":
+            elif capability == "get_schedule_summary":
                 date_range = data.get("date_range", "today")
-                result = await self.calendar_service.analyze_schedule(date_range)
+                result = await self.calendar_service.get_schedule_summary(date_range)
 
             if result:
                 await self.send_capability_response(

--- a/jarvis/services/calendar_service.py
+++ b/jarvis/services/calendar_service.py
@@ -132,8 +132,8 @@ class CalendarService:
         except Exception as e:
             return {"success": False, "error": str(e)}
 
-    async def analyze_schedule(self, date_range: str = "today") -> Dict[str, Any]:
-        """Analyze schedule and provide insights"""
+    async def get_schedule_summary(self, date_range: str = "today") -> Dict[str, Any]:
+        """Return a summary of the schedule for the given range."""
         if date_range == "today":
             today_data = await self.get_today_events()
             events = today_data.get("events", [])
@@ -144,7 +144,8 @@ class CalendarService:
                 "total_events": len(events),
                 "total_scheduled_minutes": total_time,
                 "analysis": f"You have {len(events)} events today totaling {total_time} minutes",
+                "events": events,
             }
-            self.logger.log("INFO", "Schedule analysis", str(result))
+            self.logger.log("INFO", "Schedule summary", str(result))
             return result
         return {"status": "error", "message": "Unsupported range"}


### PR DESCRIPTION
## Summary
- rename `analyze_schedule` capability to `get_schedule_summary`
- add events list to returned summary
- update capability names and function mapping

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848602554fc832a98de61772f15c03a