### PR TITLE
Fix orchestration failure when AI returns fenced JSON

### DIFF
--- a/jarvis/agents/orchestrator_agent.py
+++ b/jarvis/agents/orchestrator_agent.py
@@ -12,6 +12,7 @@ from .message import Message
 from .task import Task
 from ..ai_clients import BaseAIClient
 from ..logger import JarvisLogger
+from ..utils import extract_json_from_text
 
 
 class OrchestratorAgent(NetworkAgent):
@@ -169,9 +170,8 @@ Be thorough - include all capabilities that might be needed."""
 
         response = await self.ai_client.chat(messages, [])
 
-        try:
-            analysis = json.loads(response[0].content)
-        except Exception:
+        analysis = extract_json_from_text(response[0].content)
+        if analysis is None:
             self.logger.log("ERROR", "Failed to analyze request", response[0].content)
             return {"analysis_failed": True}
 

--- a/jarvis/utils.py
+++ b/jarvis/utils.py
@@ -1,5 +1,7 @@
 from fastapi import Request
 from tzlocal import get_localzone_name
+import json
+import re
 
 def detect_timezone(request: Request) -> str:
     """Determine the user's timezone.
@@ -9,3 +11,31 @@ def detect_timezone(request: Request) -> str:
     2. The server's local timezone.
     """
     return request.headers.get("X-Timezone") or get_localzone_name()
+
+
+def extract_json_from_text(text: str):
+    """Extract a JSON object from a text string.
+
+    The text may include a fenced code block such as ````json ...```.
+    Returns the parsed JSON dict on success or ``None`` on failure.
+    """
+
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        cleaned = cleaned.strip("`")
+        if cleaned.lower().startswith("json"):
+            cleaned = cleaned[4:]
+        cleaned = cleaned.strip()
+    if cleaned.endswith("```"):
+        cleaned = cleaned[:-3].strip()
+
+    try:
+        return json.loads(cleaned)
+    except Exception:
+        match = re.search(r"\{.*\}", text, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group(0))
+            except Exception:
+                return None
+    return None


### PR DESCRIPTION
## Summary
- improve resilience of `_analyze_request` for JSON responses
- add `extract_json_from_text` helper to handle ```json code blocks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848612f167c832a84f6bfb626e9abbc