### PR TITLE
Fix calendar add_event parameters

### DIFF
--- a/jarvis/agents/orchestrator_agent.py
+++ b/jarvis/agents/orchestrator_agent.py
@@ -194,6 +194,12 @@ Current date: {current_date}
 Available capabilities:
 {chr(10).join(available_capabilities)}
 
+Parameter guidelines:
+- add_event expects: title, date (YYYY-MM-DD) and time (HH:MM). You may also provide start_time and end_time in ISO format instead of date/time and the system will convert them. Description is optional.
+- remove_event expects: event_id.
+- view_schedule accepts an optional date.
+- get_schedule_summary accepts an optional date_range (defaults to "today").
+
 Analyze the user's request and return a JSON object with:
 - "intent": brief description of what the user wants
 - "capabilities_needed": list of capability names needed


### PR DESCRIPTION
## Summary
- support start_time and end_time in `CalendarAgent` and convert to date/time
- clarify add_event tool schema
- instruct the orchestrator about required parameters for each capability

## Testing
- `python -m py_compile jarvis/agents/calendar_agent.py jarvis/agents/orchestrator_agent.py`
- `python main.py` *(fails: waiting for user input; interrupted)*
- `pip install tzlocal python-dotenv`
- `pip install aiohttp`
- `pip install openai`
- `pip install anthropic`
- `pip install fastapi`


------
https://chatgpt.com/codex/tasks/task_e_684864b748a0832a8d33171767fe849d