### PR TITLE
Improve dependency context handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ This file gives high level guidance for working with the code base. It is intend
 ## Dependencies
 Additional Python packages used by the project:
 - `tzlocal`
+- `jmespath`
 
 ## Overview
 - **Language**: Python 3.11+

--- a/jarvis/agents/task.py
+++ b/jarvis/agents/task.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 
 @dataclass
@@ -12,5 +12,6 @@ class Task:
     capability: str
     parameters: Dict[str, Any]
     assigned_agent: Optional[str] = None
+    depends_on: List[str] = field(default_factory=list)
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     result: Any = None


### PR DESCRIPTION
## Summary
- track task dependencies directly in `Task`
- link dependency results when executing tasks
- resolve `$` references in `CollaborativeCalendarAgent`
- document new `jmespath` dependency

## Testing
- `python -m py_compile jarvis/agents/task.py jarvis/agents/orchestrator_agent.py jarvis/agents/calendar_agent.py`
- `python -m jarvis.log_viewer --help` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68486b03c410832ab3f96bb3440e7c5b