### PR TITLE
Refactor dependency handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,6 @@ This file gives high level guidance for working with the code base. It is intend
 ## Dependencies
 Additional Python packages used by the project:
 - `tzlocal`
-- `jmespath`
 
 ## Overview
 - **Language**: Python 3.11+


### PR DESCRIPTION
## Summary
- drop unused jmespath dependency
- instruct orchestrator to read `dependencies` mapping from analysis output
- look up event ID using prior schedule context when removing events

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68486d14f928832a89f09b91e2c8a21b