### PR TITLE
Improve Jarvis demo output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ This file gives high level guidance for working with the code base. It is intend
 ## Dependencies
 Additional Python packages used by the project:
 - `tzlocal`
+- `colorama`
 
 ## Overview
 - **Language**: Python 3.11+

--- a/jarvis/main_network.py
+++ b/jarvis/main_network.py
@@ -133,6 +133,7 @@ async def create_collaborative_jarvis(api_key: str = None):
         "ai_provider": "openai",
         "api_key": api_key,
         "calendar_api_url": "http://localhost:8080",
+        "response_timeout": 30.0,
     }
 
     jarvis = JarvisSystem(config)

--- a/main.py
+++ b/main.py
@@ -5,12 +5,14 @@ from dotenv import load_dotenv
 
 from jarvis.main_network import create_collaborative_jarvis
 from tzlocal import get_localzone_name
+from colorama import Fore, Style, init as colorama_init
 
 # Load environment variables from .env file
 load_dotenv()
 
 
 async def demo() -> None:
+    colorama_init(autoreset=True)
     jarvis = await create_collaborative_jarvis(os.getenv("OPENAI_API_KEY"))
 
     # Get user input for the calendar command
@@ -20,7 +22,11 @@ async def demo() -> None:
         user_command,
         get_localzone_name(),
     )
-    print(result)
+    response_text = result.get("response", "")
+    if result.get("success"):
+        print(Fore.CYAN + response_text + Style.RESET_ALL)
+    else:
+        print(Fore.RED + response_text + Style.RESET_ALL)
     await jarvis.shutdown()
 
 


### PR DESCRIPTION
## Summary
- log a second dependency: `colorama`
- use a longer default `response_timeout` in `create_collaborative_jarvis`
- colorize demo output for success/failure

## Testing
- `python -m py_compile main.py jarvis/main_network.py`

------
https://chatgpt.com/codex/tasks/task_e_6849031ac478832ab7d937f4b690192a