### PR TITLE
Refactor CalendarService for new API routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ This file gives high level guidance for working with the code base. It is intend
 Additional Python packages used by the project:
 - `tzlocal`
 - `colorama`
+- `httpx`
 
 ## Overview
 - **Language**: Python 3.11+


### PR DESCRIPTION
## Summary
- add `httpx` to dependencies
- overhaul `CalendarService` to call new modular C++ routes
- use `httpx.AsyncClient` for async HTTP requests
- add wrappers for availability, recurring and stats endpoints

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6d494f20832a8c897bda122604d8