### PR TITLE
Add cleanup for JarvisLogger connections

### DIFF
--- a/jarvis/logger.py
+++ b/jarvis/logger.py
@@ -21,6 +21,20 @@ class JarvisLogger:
             handler.setFormatter(formatter)
             self.logger.addHandler(handler)
 
+    def close(self) -> None:
+        """Close the SQLite connection if open."""
+        if getattr(self, "conn", None):
+            try:
+                self.conn.close()
+            finally:
+                self.conn = None
+
+    def __enter__(self) -> "JarvisLogger":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
     def _ensure_table(self) -> None:
         with self.conn:
             self.conn.execute(

--- a/jarvis/main_network.py
+++ b/jarvis/main_network.py
@@ -72,6 +72,7 @@ class JarvisSystem:
         """Shutdown the system"""
         await self.network.stop()
         self.logger.log("INFO", "Jarvis system shutdown complete")
+        self.logger.close()
 
 
 # Example usage and demo

--- a/server.py
+++ b/server.py
@@ -37,6 +37,7 @@ async def startup_event() -> None:
 async def shutdown_event() -> None:
     if jarvis_system:
         await jarvis_system.shutdown()
+    logger.close()
 
 
 @app.post("/jarvis")


### PR DESCRIPTION
## Summary
- ensure `JarvisLogger` can close its SQLite connection
- clean up loggers on shutdown of `JarvisSystem` and FastAPI app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da38c5404832aa509b11eedb29240