### PR TITLE
Optimize httpx client reuse

### DIFF
--- a/jarvis/main_network.py
+++ b/jarvis/main_network.py
@@ -20,6 +20,7 @@ class JarvisSystem:
         self.logger = JarvisLogger()
         self.network = AgentNetwork(self.logger)
         self.orchestrator: OrchestratorAgent | None = None
+        self.calendar_service: CalendarService | None = None
 
     async def initialize(self):
         """Initialize all agents and start the network"""
@@ -37,11 +38,11 @@ class JarvisSystem:
         self.network.register_agent(self.orchestrator)
 
         # Create Calendar Agent with integrated natural language logic
-        calendar_service = CalendarService(
+        self.calendar_service = CalendarService(
             self.config.get("calendar_api_url", "http://localhost:8080")
         )
         calendar_agent = CollaborativeCalendarAgent(
-            ai_client, calendar_service, self.logger
+            ai_client, self.calendar_service, self.logger
         )
         self.network.register_agent(calendar_agent)
 
@@ -71,6 +72,8 @@ class JarvisSystem:
     async def shutdown(self):
         """Shutdown the system"""
         await self.network.stop()
+        if self.calendar_service:
+            await self.calendar_service.close()
         self.logger.log("INFO", "Jarvis system shutdown complete")
 
 


### PR DESCRIPTION
## Summary
- initialize a single `httpx.AsyncClient` in `CalendarService`
- add `CalendarService.close()` for cleanup
- store `calendar_service` in `JarvisSystem` and close it on shutdown

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684da3855b98832ab93f04431d129d68