### PR TITLE
Fix tests section in AGENTS guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,12 @@ python -m jarvis.log_viewer
 ```
 
 ## Tests
-There are currently no automated tests. When adding new features, prefer small functions and consider adding tests under a new `tests/` folder using `pytest`.
+Automated tests live under the `tests/` directory. Install the dependencies from
+`requirements.txt` (or run `poetry install`) and execute:
+```bash
+pytest
+```
+The suite uses `pytest` and `pytest-asyncio`.
 
 ## Pull Request instructions for Agents
 1. Keep the repository in a clean state (`git status` should show no changes) before finishing.


### PR DESCRIPTION
## Summary
- clarify that automated tests exist in `tests/`
- explain how to run them with `pytest`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da954f8fc832aabab92f659be840e