### PR TITLE
Add Makefile and test instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: install test
+
+install:
+	pip install -r requirements.txt
+
+
+test:
+	pytest -vv

--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ python -m jarvis.log_viewer
 - `server.py` – FastAPI entrypoint
 - `main.py` – simple demo using `create_collaborative_jarvis`
 
+## Running tests
+Install all dependencies and run the suite with `pytest`.
+
+Using `pip`:
+```bash
+make install
+make test
+```
+
+With Poetry:
+```bash
+poetry install
+poetry run make test
+```
 
 ## License
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- provide Makefile for installing dependencies and running tests
- document how to run the tests in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684da95a3788832a9a1cd4f80b66aa6b