### PR TITLE
Fix CalendarService request payloads

### DIFF
--- a/jarvis/services/calendar_service.py
+++ b/jarvis/services/calendar_service.py
@@ -269,7 +269,7 @@ class CalendarService:
             "title": title,
         }
 
-        result = await self._request("POST", "/events/validate", data)
+        result = await self._request("POST", "/events/validate", json=data)
         valid = result.get("valid", False)
         conflicts = result.get("conflicts", [])
 
@@ -394,7 +394,7 @@ class CalendarService:
             "category": category,
         }
 
-        result = await self._request("PUT", f"/events/{event_id}", data)
+        result = await self._request("PUT", f"/events/{event_id}", json=data)
         event = result.get("data", {})
 
         return {
@@ -407,7 +407,7 @@ class CalendarService:
         self, event_id: str, fields: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Update specific fields of an event (PATCH)."""
-        result = await self._request("PATCH", f"/events/{event_id}", fields)
+        result = await self._request("PATCH", f"/events/{event_id}", json=fields)
         event = result.get("data", {})
 
         return {
@@ -435,7 +435,7 @@ class CalendarService:
             formatted_events.append(formatted_event)
 
         data = {"events": formatted_events}
-        result = await self._request("POST", "/events/bulk", data)
+        result = await self._request("POST", "/events/bulk", json=data)
         response_data = result.get("data", {})
 
         return {
@@ -448,7 +448,7 @@ class CalendarService:
     async def delete_events_bulk(self, event_ids: List[str]) -> Dict[str, Any]:
         """Delete multiple events at once."""
         data = {"ids": event_ids}
-        result = await self._request("DELETE", "/events/bulk", data)
+        result = await self._request("DELETE", "/events/bulk", json=data)
 
         return {
             "success": True,

--- a/tests/test_calendar_service.py
+++ b/tests/test_calendar_service.py
@@ -34,3 +34,124 @@ async def test_get_events_by_date(monkeypatch):
     assert result["date"] == "2024-01-01"
     assert result["event_count"] == 1
     assert result["events"][0]["title"] == "Meeting"
+
+
+@pytest.mark.asyncio
+async def test_validate_event_time_uses_json(monkeypatch):
+    service = CalendarService(base_url="http://test")
+
+    captured = {}
+
+    async def mock_request(method, endpoint, *, params=None, json=None):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["json"] = json
+        return {"valid": True, "conflicts": []}
+
+    monkeypatch.setattr(service, "_request", mock_request)
+
+    await service.validate_event_time("2024-01-02 10:00", duration_seconds=1800, title="Call")
+
+    assert captured["json"] == {
+        "time": "2024-01-02 10:00",
+        "duration": 1800,
+        "title": "Call",
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_event_uses_json(monkeypatch):
+    service = CalendarService(base_url="http://test")
+
+    expected = {
+        "title": "Meet",
+        "time": "2024-01-03 09:00",
+        "duration_seconds": 3600,
+        "description": "desc",
+        "category": "work",
+    }
+    captured = {}
+
+    async def mock_request(method, endpoint, *, params=None, json=None):
+        captured["json"] = json
+        return {"data": {"id": "123", **json}}
+
+    monkeypatch.setattr(service, "_request", mock_request)
+
+    result = await service.update_event("123", **expected)
+
+    json_expected = {
+        "title": "Meet",
+        "time": "2024-01-03 09:00",
+        "duration": 3600,
+        "description": "desc",
+        "category": "work",
+    }
+    assert captured["json"] == json_expected
+    assert result["event"]["title"] == "Meet"
+
+
+@pytest.mark.asyncio
+async def test_update_event_fields_uses_json(monkeypatch):
+    service = CalendarService(base_url="http://test")
+
+    fields = {"title": "New Title"}
+    captured = {}
+
+    async def mock_request(method, endpoint, *, params=None, json=None):
+        captured["json"] = json
+        return {"data": {"id": "1", **json, "time": "2024-01-04 08:00", "duration": 0}}
+
+    monkeypatch.setattr(service, "_request", mock_request)
+
+    await service.update_event_fields("1", fields)
+
+    assert captured["json"] == fields
+
+
+@pytest.mark.asyncio
+async def test_add_events_bulk_uses_json(monkeypatch):
+    service = CalendarService(base_url="http://test")
+
+    events = [
+        {"title": "A", "time": "2024-01-05 12:00", "duration_seconds": 3600, "description": ""}
+    ]
+    expected_json = {
+        "events": [
+            {
+                "title": "A",
+                "time": "2024-01-05 12:00",
+                "duration": 3600,
+                "description": "",
+            }
+        ]
+    }
+    captured = {}
+
+    async def mock_request(method, endpoint, *, params=None, json=None):
+        captured["json"] = json
+        return {"data": {"total": 1, "successful": 1, "results": []}}
+
+    monkeypatch.setattr(service, "_request", mock_request)
+
+    await service.add_events_bulk(events)
+
+    assert captured["json"] == expected_json
+
+
+@pytest.mark.asyncio
+async def test_delete_events_bulk_uses_json(monkeypatch):
+    service = CalendarService(base_url="http://test")
+
+    ids = ["1", "2"]
+    captured = {}
+
+    async def mock_request(method, endpoint, *, params=None, json=None):
+        captured["json"] = json
+        return {"removed": 2, "requested": 2}
+
+    monkeypatch.setattr(service, "_request", mock_request)
+
+    await service.delete_events_bulk(ids)
+
+    assert captured["json"] == {"ids": ids}


### PR DESCRIPTION
## Summary
- ensure payloads are passed via `json=` when calling `_request`
- extend tests to check json payloads for update/validate/bulk methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850fc24b4c8832ab62ef2086caced42