### PR TITLE
Modularize agent packages

### DIFF
--- a/jarvis/agents/calendar_agent/__init__.py
+++ b/jarvis/agents/calendar_agent/__init__.py
@@ -2,12 +2,11 @@
 from typing import Any, Dict, Set, List
 import json
 import uuid
-from .base import NetworkAgent
-from .message import Message
-from ..services.calendar_service import CalendarService
-from ..ai_clients import BaseAIClient
-from ..logger import JarvisLogger
-from typing import Any, Dict, Set, List
+from ..base import NetworkAgent
+from ..message import Message
+from ...services.calendar_service import CalendarService
+from ...ai_clients import BaseAIClient
+from ...logger import JarvisLogger
 from datetime import datetime, timedelta, timezone
 
 

--- a/jarvis/agents/lights_agent/__init__.py
+++ b/jarvis/agents/lights_agent/__init__.py
@@ -8,10 +8,10 @@ import json
 import time
 from typing import Any, Dict, List, Optional, Union
 from phue import Bridge
-from .base import NetworkAgent
-from .message import Message
-from ..logger import JarvisLogger
-from ..ai_clients.base import BaseAIClient
+from ..base import NetworkAgent
+from ..message import Message
+from ...logger import JarvisLogger
+from ...ai_clients.base import BaseAIClient
 
 
 class PhillipsHueAgent(NetworkAgent):

--- a/jarvis/agents/nlu_agent/__init__.py
+++ b/jarvis/agents/nlu_agent/__init__.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, List, Optional, Set
 
-from .base import NetworkAgent
-from .message import Message
-from ..ai_clients import BaseAIClient
-from ..logger import JarvisLogger
-from ..utils import extract_json_from_text
+from ..base import NetworkAgent
+from ..message import Message
+from ...ai_clients import BaseAIClient
+from ...logger import JarvisLogger
+from ...utils import extract_json_from_text
 
 
 class NLUAgent(NetworkAgent):

--- a/jarvis/agents/orchestrator_agent/__init__.py
+++ b/jarvis/agents/orchestrator_agent/__init__.py
@@ -7,12 +7,12 @@ from datetime import datetime
 from zoneinfo import ZoneInfo
 from typing import Any, Dict, List, Optional
 
-from .base import NetworkAgent
-from .message import Message
-from .task import Task
-from ..ai_clients import BaseAIClient
-from ..logger import JarvisLogger
-from ..utils import extract_json_from_text
+from ..base import NetworkAgent
+from ..message import Message
+from ..task import Task
+from ...ai_clients import BaseAIClient
+from ...logger import JarvisLogger
+from ...utils import extract_json_from_text
 
 
 class OrchestratorAgent(NetworkAgent):

--- a/jarvis/agents/protocal_agent/__init__.py
+++ b/jarvis/agents/protocal_agent/__init__.py
@@ -7,9 +7,9 @@ import os
 import uuid
 from typing import Any, Dict, List, Optional, Set
 
-from .base import NetworkAgent
-from .message import Message
-from ..logger import JarvisLogger
+from ..base import NetworkAgent
+from ..message import Message
+from ...logger import JarvisLogger
 
 
 class ProtocolAgent(NetworkAgent):


### PR DESCRIPTION
## Summary
- move each agent into its own package directory
- adjust relative imports inside agents

## Testing
- `pip install -q httpx openai anthropic fastapi uvicorn pydantic aiohttp tzlocal colorama python-dotenv pytest-asyncio phue`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853961a4990832abab8902a0a4d6cef