### PR TITLE
Add default protocol loader and sample protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Agent activity is stored in `jarvis_logs.db`. Launch the interactive viewer with
 python -m jarvis.log_viewer
 ```
 
+## Default protocols
+Several common protocols are provided under `jarvis/protocols/defaults`. To load
+them into `protocols.db` run:
+```bash
+python -m jarvis.protocols.defaults.loader
+```
+
 ## Project structure
 - `jarvis/` – main package with agent implementations and utilities
 - `server.py` – FastAPI entrypoint

--- a/jarvis/protocols/defaults/__init__.py
+++ b/jarvis/protocols/defaults/__init__.py
@@ -1,0 +1,3 @@
+from .loader import load_default_protocols
+
+__all__ = ["load_default_protocols"]

--- a/jarvis/protocols/defaults/check_today_schedule.json
+++ b/jarvis/protocols/defaults/check_today_schedule.json
@@ -1,0 +1,7 @@
+{
+  "name": "check_today_schedule",
+  "description": "Show events scheduled for today",
+  "steps": [
+    {"intent": "get_today_schedule", "parameters": {"command": "Check my schedule for today"}}
+  ]
+}

--- a/jarvis/protocols/defaults/loader.py
+++ b/jarvis/protocols/defaults/loader.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+from .. import Protocol, ProtocolStep
+from ..registry import ProtocolRegistry
+
+
+def load_default_protocols(registry: ProtocolRegistry, directory: str | Path | None = None) -> None:
+    """Load all JSON protocol definitions in *directory* into the registry."""
+    if directory is None:
+        directory = Path(__file__).parent
+    else:
+        directory = Path(directory)
+
+    for file_path in directory.glob("*.json"):
+        data = json.loads(file_path.read_text())
+        steps = [ProtocolStep(intent=s.get("intent"), parameters=s.get("parameters", {})) for s in data.get("steps", [])]
+        proto = Protocol(
+            id=str(uuid.uuid4()),
+            name=data["name"],
+            description=data.get("description", ""),
+            steps=steps,
+        )
+        registry.register(proto)
+
+
+def main() -> None:
+    registry = ProtocolRegistry()
+    load_default_protocols(registry)
+
+
+if __name__ == "__main__":  # pragma: no cover - utility script
+    main()

--- a/jarvis/protocols/defaults/turn_lights_blue.json
+++ b/jarvis/protocols/defaults/turn_lights_blue.json
@@ -1,0 +1,7 @@
+{
+  "name": "turn_lights_blue",
+  "description": "Set all connected lights to blue",
+  "steps": [
+    {"intent": "hue_command", "parameters": {"command": "Turn the lights blue"}}
+  ]
+}


### PR DESCRIPTION
## Summary
- add new directory `jarvis/protocols/defaults`
- include two example protocol definitions (lights and schedule)
- provide loader script to import all default protocols
- document how to load defaults in README

## Testing
- `pip install -r requirements.txt`
- `pip install phue`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543462639c832ab1201d971db3a8f0