### PR TITLE
Add CLI to run protocols from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,15 @@ python -m jarvis.log_viewer
 ```
 
 ## Default protocols
-Several common protocols are provided under `jarvis/protocols/defaults`. To load
-them into `protocols.db` run:
+Several common protocols are provided under `jarvis/protocols/defaults`.
+To load them into `protocols.db` run:
 ```bash
-python -m jarvis.protocols.defaults.loader
+python -m jarvis.protocols.defaults.loader load
+```
+
+You can also run a protocol directly from a JSON file:
+```bash
+python -m jarvis.protocols.defaults.loader run path/to/protocol.json
 ```
 
 ## Project structure

--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -11,7 +11,11 @@ from .ai_clients import (
 )
 from .agents.agent_network import AgentNetwork
 from .agents.calendar_agent import CollaborativeCalendarAgent
-from .main_jarvis import JarvisSystem, create_collaborative_jarvis
+try:  # Optional import to avoid heavy dependencies during module import
+    from .main_jarvis import JarvisSystem, create_collaborative_jarvis
+except Exception:  # pragma: no cover - optional dependency may be missing
+    JarvisSystem = None
+    create_collaborative_jarvis = None
 from .protocols import Protocol, ProtocolStep
 from .protocols.registry import ProtocolRegistry
 from .protocols.executor import ProtocolExecutor

--- a/jarvis/protocols/builder.py
+++ b/jarvis/protocols/builder.py
@@ -38,14 +38,7 @@ def create_interactively(registry: ProtocolRegistry) -> Protocol:
 
 
 def create_from_file(file_path: str, registry: ProtocolRegistry) -> Protocol:
-    data = json.loads(Path(file_path).read_text())
-    steps = [ProtocolStep(**s) for s in data.get("steps", [])]
-    proto = Protocol(
-        id=str(uuid.uuid4()),
-        name=data["name"],
-        description=data.get("description", ""),
-        steps=steps,
-    )
+    proto = Protocol.from_file(file_path)
     registry.register(proto)
     return proto
 


### PR DESCRIPTION
## Summary
- support creating protocols from dictionaries and files
- update protocol builder to use helper
- add loader CLI command to run protocol files
- adjust package imports to avoid optional deps during tests
- document running default protocols or custom files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543c238af4832a820f915d7ad154e1