### PR TITLE
Execute protocol tools directly

### DIFF
--- a/jarvis/protocols/executor.py
+++ b/jarvis/protocols/executor.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import uuid
 from typing import Any, Dict
 
+import asyncio
+from functools import partial
+
 from ..logger import JarvisLogger
 from ..agents.agent_network import AgentNetwork
 from . import Protocol
@@ -15,19 +18,58 @@ class ProtocolExecutor:
         self.network = network
         self.logger = logger
 
-    async def execute(self, protocol: Protocol, extra_params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    async def execute(
+        self, protocol: Protocol, extra_params: Dict[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        """Run each step in *protocol* synchronously without AI reasoning."""
+
         results: Dict[str, Any] = {}
         extra_params = extra_params or {}
+
         for step in protocol.steps:
             capability = step.intent
             providers = self.network.capability_registry.get(capability, [])
             if not providers:
                 self.logger.log(
-                    "ERROR", f"No provider for capability '{capability}'"
+                    "ERROR",
+                    f"No provider for capability '{capability}'",
                 )
                 results[step.intent] = {"error": "no_provider"}
                 continue
 
+            provider = self.network.agents.get(providers[0])
+            if not provider:
+                self.logger.log(
+                    "ERROR",
+                    f"Provider '{providers[0]}' not found for '{capability}'",
+                )
+                results[step.intent] = {"error": "no_provider"}
+                continue
+
+            mapping = getattr(provider, "intent_tool_map", None)
+            if mapping and capability in mapping:
+                func = mapping[capability]
+                params = {**step.parameters, **extra_params}
+                try:
+                    if asyncio.iscoroutinefunction(func):
+                        result = await func(**params)
+                    else:
+                        loop = asyncio.get_running_loop()
+                        result = await loop.run_in_executor(
+                            None, partial(func, **params)
+                        )
+                    results[step.intent] = result
+                    continue
+                except Exception as exc:  # pragma: no cover - error path
+                    self.logger.log(
+                        "ERROR",
+                        f"Error executing {capability} via tool",
+                        str(exc),
+                    )
+                    results[step.intent] = {"error": str(exc)}
+                    continue
+
+            # Fallback to legacy capability request/response
             request_id = str(uuid.uuid4())
             params = {**step.parameters, **extra_params}
             await self.network.request_capability(
@@ -41,4 +83,5 @@ class ProtocolExecutor:
                 results[step.intent] = response
             except Exception as exc:
                 results[step.intent] = {"error": str(exc)}
+
         return results

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -11,20 +11,14 @@ from jarvis.logger import JarvisLogger
 class DummyAgent(NetworkAgent):
     def __init__(self):
         super().__init__("dummy")
-        self.received = asyncio.Queue()
+        self.intent_tool_map = {"dummy_cap": self.echo}
 
     @property
     def capabilities(self):
         return {"dummy_cap"}
 
-    async def _handle_capability_request(self, message):
-        await self.received.put(message)
-        await self.send_capability_response(
-            message.from_agent,
-            {"echo": message.content.get("data")},
-            message.request_id,
-            message.id,
-        )
+    async def echo(self, **kwargs):
+        return {"echo": kwargs}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- revise `ProtocolExecutor.execute` to call agent tools directly when available
- adjust protocol test to provide a dummy agent with a tool map

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543e734518832aae5aff2e54441bd4