### PR TITLE
Refactor protocol execution with arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,39 @@ You can also run a protocol directly from a JSON file:
 python -m jarvis.protocols.defaults.loader run path/to/protocol.json
 ```
 
+### Protocol arguments
+Protocols can define an `arguments` object which specifies parameter names and default values.
+When executed, you may pass a dictionary of values that override these defaults. Parameter values
+within each step can reference arguments using Python `str.format` syntax.
+
+Example protocol definition:
+
+```json
+{
+  "name": "greet",
+  "description": "Echo a greeting twice",
+  "arguments": {"name": "world"},
+  "steps": [
+    {"intent": "dummy_cap", "parameters": {"text": "Hello {name}"}},
+    {"intent": "dummy_cap", "parameters": {"text": "Bye {name}"}}
+  ]
+}
+```
+
+Manually executing this protocol:
+
+```python
+from jarvis.protocols import ProtocolExecutor, Protocol
+from jarvis.agents.agent_network import AgentNetwork
+from jarvis.logger import JarvisLogger
+
+network = AgentNetwork()
+# register agents with `intent_map` entries...
+executor = ProtocolExecutor(network, JarvisLogger())
+proto = Protocol.from_file("greet.json")
+results = await executor.execute(proto, {"name": "Alice"})
+```
+
 ## Project structure
 - `jarvis/` – main package with agent implementations and utilities
 - `server.py` – FastAPI entrypoint

--- a/jarvis/agents/base.py
+++ b/jarvis/agents/base.py
@@ -17,6 +17,8 @@ class NetworkAgent:
         self.logger = logger or JarvisLogger()
         self.active_tasks: Dict[str, Any] = {}
         self.message_handlers: Dict[str, Callable] = {}
+        # Map intent names to bound methods for direct invocation
+        self.intent_map: Dict[str, Callable] = {}
         self._setup_base_handlers()
 
     @property

--- a/jarvis/agents/protocal_agent/__init__.py
+++ b/jarvis/agents/protocal_agent/__init__.py
@@ -55,12 +55,19 @@ class ProtocolAgent(NetworkAgent):
         name = data.get("name")
         description = data.get("description", "")
         raw_steps = data.get("steps", [])
+        arguments = data.get("arguments", {}) or {}
         if not name or not isinstance(raw_steps, list):
             await self.send_error(message.from_agent, "Invalid protocol definition", message.request_id)
             return
 
         steps = [ProtocolStep(intent=s.get("intent"), parameters=s.get("parameters", {})) for s in raw_steps]
-        proto = Protocol(id=str(uuid.uuid4()), name=name, description=description, steps=steps)
+        proto = Protocol(
+            id=str(uuid.uuid4()),
+            name=name,
+            description=description,
+            arguments=arguments,
+            steps=steps,
+        )
         self.registry.register(proto)
         self._sync_registry()
         await self.send_capability_response(
@@ -91,6 +98,7 @@ class ProtocolAgent(NetworkAgent):
                 "id": proto.id,
                 "name": proto.name,
                 "description": proto.description,
+                "arguments": proto.arguments,
                 "steps": [step.__dict__ for step in proto.steps],
             },
             request_id=message.request_id,

--- a/jarvis/protocols/__init__.py
+++ b/jarvis/protocols/__init__.py
@@ -27,6 +27,7 @@ class Protocol:
     id: str
     name: str
     description: str
+    arguments: Dict[str, Any] = field(default_factory=dict)
     steps: List[ProtocolStep] = field(default_factory=list)
 
     @classmethod
@@ -39,6 +40,7 @@ class Protocol:
             id=pid,
             name=data["name"],
             description=data.get("description", ""),
+            arguments=data.get("arguments", {}),
             steps=steps,
         )
 

--- a/jarvis/protocols/defaults/greet.json
+++ b/jarvis/protocols/defaults/greet.json
@@ -1,0 +1,9 @@
+{
+  "name": "greet",
+  "description": "Echo a greeting twice",
+  "arguments": {"name": "world"},
+  "steps": [
+    {"intent": "dummy_cap", "parameters": {"text": "Hello {name}"}},
+    {"intent": "dummy_cap", "parameters": {"text": "Bye {name}"}}
+  ]
+}

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -11,7 +11,7 @@ from jarvis.logger import JarvisLogger
 class DummyAgent(NetworkAgent):
     def __init__(self):
         super().__init__("dummy")
-        self.intent_tool_map = {"dummy_cap": self.echo}
+        self.intent_map = {"dummy_cap": self.echo}
 
     @property
     def capabilities(self):
@@ -31,10 +31,10 @@ async def test_protocol_execution():
     logger = JarvisLogger()
     executor = ProtocolExecutor(network, logger)
 
-    step = ProtocolStep(intent="dummy_cap", parameters={"foo": "bar"})
-    proto = Protocol(id="1", name="test", description="", steps=[step])
+    step = ProtocolStep(intent="dummy_cap", parameters={"msg": "Hello {name}"})
+    proto = Protocol(id="1", name="test", description="", arguments={"name": "world"}, steps=[step])
 
-    result = await executor.execute(proto)
+    result = await executor.execute(proto, {"name": "Jarvis"})
     await network.stop()
 
-    assert result["dummy_cap"]["echo"] == {"foo": "bar"}
+    assert result["dummy_cap"]["echo"] == {"name": "Jarvis", "msg": "Hello Jarvis"}


### PR DESCRIPTION
## Summary
- enable argument definitions for `Protocol`
- route protocol execution directly to agent method maps
- expose agent `intent_map` for direct callable references
- support saving/loading arguments in `ProtocolRegistry`
- document new protocol argument system with example
- update protocol tests for the new flow

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685444656d94832aa83c1c58166978a2