### PR TITLE
Add protocol trigger matching and run helper

### DIFF
--- a/jarvis/protocols/executor.py
+++ b/jarvis/protocols/executor.py
@@ -17,6 +17,12 @@ class ProtocolExecutor:
         self.network = network
         self.logger = logger
 
+    async def run_protocol(
+        self, protocol: Protocol, arguments: Dict[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        """Public helper to execute a protocol."""
+        return await self.execute(protocol, arguments)
+
     async def execute(
         self, protocol: Protocol, context: Dict[str, Any] | None = None
     ) -> Dict[str, Any]:

--- a/tests/test_protocol_registry.py
+++ b/tests/test_protocol_registry.py
@@ -33,3 +33,19 @@ def test_register_duplicate_triggers(tmp_path):
     assert result == {"success": False, "reason": "Duplicate trigger phrases"}
     assert registry.get("2") is None
     registry.close()
+
+
+def test_find_matching_protocol(tmp_path):
+    registry = ProtocolRegistry(db_path=str(tmp_path / "db.sqlite"))
+    proto1 = make_protocol("1", "Sleep Mode", ["sleep mode", "goodnight"])
+    proto2 = make_protocol("2", "Movie Mode", ["movie mode", "start movie mode"])
+    registry.register(proto1)
+    registry.register(proto2)
+
+    match = registry.find_matching_protocol("Start movie mode")
+    assert match is not None
+    assert match.name == "Movie Mode"
+
+    no_match = registry.find_matching_protocol("unknown command")
+    assert no_match is None
+    registry.close()

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -34,7 +34,7 @@ async def test_protocol_execution():
     step = ProtocolStep(agent="dummy", function="dummy_cap", parameters={"msg": "Hello {name}"})
     proto = Protocol(id="1", name="test", description="", arguments={"name": "world"}, steps=[step])
 
-    result = await executor.execute(proto, {"name": "Jarvis"})
+    result = await executor.run_protocol(proto, {"name": "Jarvis"})
     await network.stop()
 
     assert result["step_0_dummy_cap"]["echo"] == {"msg": "Hello {name}"}


### PR DESCRIPTION
## Summary
- search input text for protocol trigger phrases with new registry helper
- expose `run_protocol` helper in `ProtocolExecutor`
- automatically run matched protocol in `JarvisSystem.process_request`
- test trigger matching and run helper

## Testing
- `pip install httpx aiohttp tzlocal colorama python-dotenv fastapi uvicorn pydantic openai anthropic pytest pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68550195124c832a8347aeeb5b496cce