### PR TITLE
Improve HTTP client lifetime management

### DIFF
--- a/jarvis/services/calendar_service.py
+++ b/jarvis/services/calendar_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple, Union
+import types
 
 import httpx
 
@@ -19,6 +20,18 @@ class CalendarService:
         self.base_url = base_url
         self.logger = logger or JarvisLogger()
         self.client = httpx.AsyncClient()
+
+    async def __aenter__(self) -> "CalendarService":
+        """Allow use as an async context manager."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[types.TracebackType],
+    ) -> None:
+        await self.close()
 
     def _format_event(self, event: Dict[str, Any]) -> Dict[str, Any]:
         """Normalize event structure returned by the API."""

--- a/tests/test_calendar_service.py
+++ b/tests/test_calendar_service.py
@@ -10,14 +10,14 @@ class MockResponse:
 
 @pytest.mark.asyncio
 async def test_get_events_by_date(monkeypatch):
-    service = CalendarService(base_url="http://test")
+    async with CalendarService(base_url="http://test") as service:
 
-    async def mock_request(method, url, params=None, json=None):
-        assert method == "GET"
-        assert url.endswith("/events/day/2024-01-01")
-        return MockResponse({
-            "data": [
-                {
+        async def mock_request(method, url, params=None, json=None):
+            assert method == "GET"
+            assert url.endswith("/events/day/2024-01-01")
+            return MockResponse({
+                "data": [
+                    {
                     "id": "1",
                     "title": "Meeting",
                     "time": "2024-01-01 10:00",
@@ -28,130 +28,125 @@ async def test_get_events_by_date(monkeypatch):
             ]
         })
 
-    monkeypatch.setattr(service.client, "request", mock_request)
-    result = await service.get_events_by_date("2024-01-01")
+        monkeypatch.setattr(service.client, "request", mock_request)
+        result = await service.get_events_by_date("2024-01-01")
 
-    assert result["date"] == "2024-01-01"
-    assert result["event_count"] == 1
-    assert result["events"][0]["title"] == "Meeting"
+        assert result["date"] == "2024-01-01"
+        assert result["event_count"] == 1
+        assert result["events"][0]["title"] == "Meeting"
 
 
 @pytest.mark.asyncio
 async def test_validate_event_time_uses_json(monkeypatch):
-    service = CalendarService(base_url="http://test")
+    async with CalendarService(base_url="http://test") as service:
+        captured = {}
 
-    captured = {}
+        async def mock_request(method, endpoint, *, params=None, json=None):
+            captured["method"] = method
+            captured["endpoint"] = endpoint
+            captured["json"] = json
+            return {"valid": True, "conflicts": []}
 
-    async def mock_request(method, endpoint, *, params=None, json=None):
-        captured["method"] = method
-        captured["endpoint"] = endpoint
-        captured["json"] = json
-        return {"valid": True, "conflicts": []}
+        monkeypatch.setattr(service, "_request", mock_request)
 
-    monkeypatch.setattr(service, "_request", mock_request)
+        await service.validate_event_time("2024-01-02 10:00", duration_seconds=1800, title="Call")
 
-    await service.validate_event_time("2024-01-02 10:00", duration_seconds=1800, title="Call")
-
-    assert captured["json"] == {
-        "time": "2024-01-02 10:00",
-        "duration": 1800,
-        "title": "Call",
-    }
+        assert captured["json"] == {
+            "time": "2024-01-02 10:00",
+            "duration": 1800,
+            "title": "Call",
+        }
 
 
 @pytest.mark.asyncio
 async def test_update_event_uses_json(monkeypatch):
-    service = CalendarService(base_url="http://test")
-
-    expected = {
+    async with CalendarService(base_url="http://test") as service:
+        expected = {
         "title": "Meet",
         "time": "2024-01-03 09:00",
         "duration_seconds": 3600,
         "description": "desc",
         "category": "work",
-    }
-    captured = {}
+        }
+        captured = {}
 
-    async def mock_request(method, endpoint, *, params=None, json=None):
-        captured["json"] = json
-        return {"data": {"id": "123", **json}}
+        async def mock_request(method, endpoint, *, params=None, json=None):
+            captured["json"] = json
+            return {"data": {"id": "123", **json}}
 
-    monkeypatch.setattr(service, "_request", mock_request)
+        monkeypatch.setattr(service, "_request", mock_request)
 
-    result = await service.update_event("123", **expected)
+        result = await service.update_event("123", **expected)
 
-    json_expected = {
-        "title": "Meet",
-        "time": "2024-01-03 09:00",
-        "duration": 3600,
-        "description": "desc",
-        "category": "work",
-    }
-    assert captured["json"] == json_expected
-    assert result["event"]["title"] == "Meet"
+        json_expected = {
+            "title": "Meet",
+            "time": "2024-01-03 09:00",
+            "duration": 3600,
+            "description": "desc",
+            "category": "work",
+        }
+        assert captured["json"] == json_expected
+        assert result["event"]["title"] == "Meet"
 
 
 @pytest.mark.asyncio
 async def test_update_event_fields_uses_json(monkeypatch):
-    service = CalendarService(base_url="http://test")
+    async with CalendarService(base_url="http://test") as service:
+        fields = {"title": "New Title"}
+        captured = {}
 
-    fields = {"title": "New Title"}
-    captured = {}
+        async def mock_request(method, endpoint, *, params=None, json=None):
+            captured["json"] = json
+            return {"data": {"id": "1", **json, "time": "2024-01-04 08:00", "duration": 0}}
 
-    async def mock_request(method, endpoint, *, params=None, json=None):
-        captured["json"] = json
-        return {"data": {"id": "1", **json, "time": "2024-01-04 08:00", "duration": 0}}
+        monkeypatch.setattr(service, "_request", mock_request)
 
-    monkeypatch.setattr(service, "_request", mock_request)
+        await service.update_event_fields("1", fields)
 
-    await service.update_event_fields("1", fields)
-
-    assert captured["json"] == fields
+        assert captured["json"] == fields
 
 
 @pytest.mark.asyncio
 async def test_add_events_bulk_uses_json(monkeypatch):
-    service = CalendarService(base_url="http://test")
-
-    events = [
-        {"title": "A", "time": "2024-01-05 12:00", "duration_seconds": 3600, "description": ""}
-    ]
-    expected_json = {
-        "events": [
-            {
-                "title": "A",
-                "time": "2024-01-05 12:00",
-                "duration": 3600,
-                "description": "",
-            }
+    async with CalendarService(base_url="http://test") as service:
+        events = [
+            {"title": "A", "time": "2024-01-05 12:00", "duration_seconds": 3600, "description": ""}
         ]
-    }
-    captured = {}
+        expected_json = {
+            "events": [
+                {
+                    "title": "A",
+                    "time": "2024-01-05 12:00",
+                    "duration": 3600,
+                    "description": "",
+                }
+            ]
+        }
+        captured = {}
 
-    async def mock_request(method, endpoint, *, params=None, json=None):
-        captured["json"] = json
-        return {"data": {"total": 1, "successful": 1, "results": []}}
+        async def mock_request(method, endpoint, *, params=None, json=None):
+            captured["json"] = json
+            return {"data": {"total": 1, "successful": 1, "results": []}}
 
-    monkeypatch.setattr(service, "_request", mock_request)
+        monkeypatch.setattr(service, "_request", mock_request)
 
-    await service.add_events_bulk(events)
+        await service.add_events_bulk(events)
 
-    assert captured["json"] == expected_json
+        assert captured["json"] == expected_json
 
 
 @pytest.mark.asyncio
 async def test_delete_events_bulk_uses_json(monkeypatch):
-    service = CalendarService(base_url="http://test")
+    async with CalendarService(base_url="http://test") as service:
+        ids = ["1", "2"]
+        captured = {}
 
-    ids = ["1", "2"]
-    captured = {}
+        async def mock_request(method, endpoint, *, params=None, json=None):
+            captured["json"] = json
+            return {"removed": 2, "requested": 2}
 
-    async def mock_request(method, endpoint, *, params=None, json=None):
-        captured["json"] = json
-        return {"removed": 2, "requested": 2}
+        monkeypatch.setattr(service, "_request", mock_request)
 
-    monkeypatch.setattr(service, "_request", mock_request)
+        await service.delete_events_bulk(ids)
 
-    await service.delete_events_bulk(ids)
-
-    assert captured["json"] == {"ids": ids}
+        assert captured["json"] == {"ids": ids}


### PR DESCRIPTION
## Summary
- manage `CalendarService` HTTP client with async context manager
- update tests to use new async context manager

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68559690bc78832a8d45207436206d68