### PR TITLE
Implement directory loading in protocol registry

### DIFF
--- a/jarvis/protocols/registry.py
+++ b/jarvis/protocols/registry.py
@@ -47,7 +47,17 @@ class ProtocolRegistry:
     def load(self, directory: Path | None = None) -> None:
         self.protocols.clear()
         if directory is not None:
-            # … unchanged …
+            directory = Path(directory)
+            if not directory.exists():
+                print(f"Directory {directory} does not exist")
+                return
+
+            for json_file in directory.glob("*.json"):
+                try:
+                    protocol = Protocol.from_file(json_file)
+                    self.register(protocol)
+                except Exception as e:
+                    print(f"Failed to load protocol from {json_file}: {e}")
             return
 
         rows = self.conn.execute(


### PR DESCRIPTION
## Summary
- support loading protocol definitions from a directory of JSON files

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855992bf614832a8373d7c014f80c62