### PR TITLE
Add MongoDB logging for protocol execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Additional Python packages used by the project:
 - `anthropic`
 - `pytest`
 - `pytest-asyncio`
+- `pymongo`
 
 ## Overview
 - **Language**: Python 3.11+

--- a/jarvis/protocols/mongo_logger.py
+++ b/jarvis/protocols/mongo_logger.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+from pymongo import MongoClient
+import asyncio
+
+
+class ProtocolUsageLogger:
+    """Write protocol execution logs to MongoDB."""
+
+    def __init__(self, mongo_uri: str = "mongodb://localhost:27017", db_name: str = "jarvis") -> None:
+        self.client = MongoClient(mongo_uri)
+        self.collection = self.client[db_name]["protocol_usage_history"]
+        # Ensure indexes for common queries
+        self.collection.create_index("protocol_name")
+        self.collection.create_index("day_of_week")
+        self.collection.create_index("hour")
+
+    async def log_usage(self, log_doc: Dict[str, Any]) -> None:
+        """Insert a log document."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self.collection.insert_one, log_doc)
+
+from datetime import datetime
+
+
+def _time_of_day(hour: int) -> str:
+    if 5 <= hour < 12:
+        return "morning"
+    if 12 <= hour < 17:
+        return "afternoon"
+    if 17 <= hour < 21:
+        return "evening"
+    return "night"
+
+
+REQUIRED_FIELDS = [
+    "protocol_name",
+    "protocol_id",
+    "arguments",
+    "steps",
+    "timestamp",
+    "day_of_week",
+    "hour",
+    "time_of_day",
+    "device",
+    "location",
+    "trigger_phrase_used",
+    "user",
+    "source",
+    "execution_result",
+    "latency_ms",
+]
+
+
+def generate_protocol_log(protocol, arguments: Dict[str, Any], trigger_phrase: str | None, metadata: Dict[str, Any] | None) -> Dict[str, Any]:
+    """Create a log document for protocol execution."""
+    metadata = metadata or {}
+    now = datetime.utcnow()
+    hour = now.hour
+    log_doc = {
+        "protocol_name": protocol.name,
+        "protocol_id": protocol.id,
+        "arguments": arguments or {},
+        "steps": [
+            {"agent": s.agent, "function": s.function, "parameters": s.parameters}
+            for s in getattr(protocol, "steps", [])
+        ],
+        "timestamp": now,
+        "day_of_week": now.strftime("%A"),
+        "hour": hour,
+        "time_of_day": _time_of_day(hour),
+        "device": metadata.get("device"),
+        "location": metadata.get("location"),
+        "trigger_phrase_used": trigger_phrase,
+        "user": metadata.get("user"),
+        "source": metadata.get("source"),
+        "execution_result": metadata.get("execution_result"),
+        "latency_ms": metadata.get("latency_ms"),
+    }
+    # Ensure all fields exist
+    for field in REQUIRED_FIELDS:
+        log_doc.setdefault(field, None)
+    return log_doc

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ async def demo() -> None:
     result = await jarvis.process_request(
         user_command,
         get_localzone_name(),
+        {},
     )
     response_data = result.get("response", "")
 
@@ -65,7 +66,7 @@ async def demo() -> None:
 
 async def calendar_ai(command: str, api_key: Optional[str] = None) -> str:
     jarvis = await create_collaborative_jarvis(api_key or os.getenv("OPENAI_API_KEY"))
-    result = await jarvis.process_request(command, get_localzone_name())
+    result = await jarvis.process_request(command, get_localzone_name(), {})
     await jarvis.shutdown()
     return result["response"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ python-dotenv = "1.0.1"
 pydantic = "2.7.1"
 openai = "1.11.0"
 anthropic = "0.10.0"
+pymongo = "4.13.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ openai==1.11.0
 anthropic==0.10.0
 pytest==8.3.5
 pytest-asyncio==0.23.6
+pymongo==4.13.2

--- a/server.py
+++ b/server.py
@@ -59,7 +59,13 @@ async def jarvis(
 ):
     """Execute a command using the agent network."""
     tz_name = detect_timezone(request)
-    return await jarvis_system.process_request(req.command, tz_name)
+    metadata = {
+        "device": request.headers.get("X-Device"),
+        "location": request.headers.get("X-Location"),
+        "user": request.headers.get("X-User"),
+        "source": request.headers.get("X-Source", "text"),
+    }
+    return await jarvis_system.process_request(req.command, tz_name, metadata)
 
 
 def run():


### PR DESCRIPTION
## Summary
- log protocol executions to MongoDB via new `ProtocolUsageLogger`
- store execution metadata with `generate_protocol_log`
- hook usage logger into `ProtocolExecutor` and `JarvisSystem`
- pass metadata from FastAPI endpoint
- add `pymongo` dependency

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856d8d69fc8832a9d6aa6456334e8ce