### PR TITLE
Add actionable SoftwareEngineeringAgent

### DIFF
--- a/jarvis/agents/__init__.py
+++ b/jarvis/agents/__init__.py
@@ -6,6 +6,7 @@ from .task import Task
 from .base import NetworkAgent
 from .agent_network import AgentNetwork
 from .protocol_agent import ProtocolAgent
+from .software_engineering_agent import SoftwareEngineeringAgent
 
 __all__ = [
     "CollaborativeCalendarAgent",
@@ -14,4 +15,5 @@ __all__ = [
     "NetworkAgent",
     "AgentNetwork",
     "ProtocolAgent",
+    "SoftwareEngineeringAgent",
 ]

--- a/jarvis/agents/software_engineering_agent/__init__.py
+++ b/jarvis/agents/software_engineering_agent/__init__.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import asyncio
+import functools
+import json
+from typing import Any, Dict, List, Optional
+
+from ..base import NetworkAgent
+from ..message import Message
+from ...logger import JarvisLogger
+from ...ai_clients.base import BaseAIClient
+from ...services.aider_service import AiderService, create_aider_service
+from .tools import (
+    code_tools,
+    testing_tools,
+    git_tools,
+    github_tools,
+    filesystem_tools,
+    memory_tools,
+)
+
+
+class SoftwareEngineeringAgent(NetworkAgent):
+    """Agent for automating software development workflows."""
+
+    def __init__(
+        self,
+        ai_client: BaseAIClient,
+        repo_path: str,
+        logger: Optional[JarvisLogger] = None,
+        aider_service: Optional[AiderService] = None,
+    ) -> None:
+        super().__init__("SoftwareEngineeringAgent", logger)
+        self.ai_client = ai_client
+        self.repo_path = repo_path
+        self.service = aider_service or create_aider_service()
+        self.todos: List[str] = []
+
+        # Aggregate all tool schemas
+        self.tools: List[Dict[str, Any]] = (
+            code_tools
+            + testing_tools
+            + git_tools
+            + github_tools
+            + filesystem_tools
+            + memory_tools
+        )
+
+        self.system_prompt = (
+            "You are SoftwareEngineeringAgent, an AI that manages codebases. "
+            "Respond to developer requests by selecting and executing the proper tools. "
+            "Use only the tools provided. Keep responses concise."
+        )
+
+        # Map tool names to bound methods for execution
+        self.intent_map = {
+            "generate_function": self.generate_function,
+            "refactor_code": self.refactor_code,
+            "add_documentation": self.add_documentation,
+            "explain_code": self.explain_code,
+            "write_tests": self.write_tests,
+            "run_tests": self.run_tests,
+            "check_coverage": self.check_coverage,
+            "git_diff": self.git_diff,
+            "git_commit": self.git_commit,
+            "git_push": self.git_push,
+            "create_pull_request": self.create_pull_request,
+            "merge_pull_request": self.merge_pull_request,
+            "read_file": self.read_file,
+            "write_file": self.write_file,
+            "list_directory": self.list_directory,
+            "create_todo": self.create_todo,
+            "snapshot_memory": self.snapshot_memory,
+        }
+
+    @property
+    def description(self) -> str:
+        return "Automates code generation, testing, and Git/GitHub tasks."
+
+    @property
+    def capabilities(self) -> set[str]:
+        return {
+            "software_command",
+            "generate_function",
+            "refactor_code",
+            "add_documentation",
+            "explain_code",
+            "write_tests",
+            "run_tests",
+            "check_coverage",
+            "git_diff",
+            "git_commit",
+            "git_push",
+            "create_pull_request",
+            "merge_pull_request",
+            "read_file",
+            "write_file",
+            "list_directory",
+            "create_todo",
+            "snapshot_memory",
+        }
+
+    async def _execute_function(self, name: str, args: Dict[str, Any]) -> Any:
+        """Execute a tool function via the intent map."""
+        func = self.intent_map.get(name)
+        if not func:
+            return {"error": f"Unknown tool {name}"}
+
+        loop = asyncio.get_running_loop()
+        try:
+            call = functools.partial(func, **args)
+            result = await loop.run_in_executor(None, call)
+        except Exception as exc:  # pragma: no cover - placeholder
+            result = {"error": str(exc)}
+        return result
+
+    async def _process_dev_command(self, command: str) -> Dict[str, Any]:
+        """Run a developer instruction through the AI model and execute tools."""
+        messages = [
+            {"role": "system", "content": self.system_prompt},
+            {"role": "user", "content": command},
+        ]
+        actions: List[Dict[str, Any]] = []
+        iterations = 0
+        MAX_ITERS = 10
+
+        while iterations < MAX_ITERS:
+            message, tool_calls = await self.ai_client.chat(messages, self.tools)
+            if not tool_calls:
+                break
+
+            messages.append(message.model_dump())
+            for call in tool_calls:
+                name = call.function.name
+                args = json.loads(call.function.arguments)
+                result = await self._execute_function(name, args)
+                actions.append({"function": name, "arguments": args, "result": result})
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": call.id,
+                        "content": json.dumps(result),
+                    }
+                )
+            iterations += 1
+
+        response_text = getattr(message, "content", "")
+        return {"response": response_text, "actions": actions}
+
+    async def _run_service(self, func: Any, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        """Run a blocking service method in an executor and return dict output."""
+        loop = asyncio.get_running_loop()
+
+        def call() -> Dict[str, Any]:
+            result = func(*args, **kwargs)
+            if hasattr(result, "to_dict"):
+                return result.to_dict()
+            return result
+
+        return await loop.run_in_executor(None, call)
+
+    # === Tool method implementations ===
+    async def generate_function(self, spec: str, file_path: str) -> Dict[str, Any]:
+        return await self._run_service(
+            self.service.aider.send_message,
+            repo_path=self.repo_path,
+            message=spec,
+            files=[file_path],
+        )
+
+    async def refactor_code(self, file_path: str, instructions: str) -> Dict[str, Any]:
+        return await self._run_service(
+            self.service.aider.refactor_code,
+            repo_path=self.repo_path,
+            file_path=file_path,
+            refactor_description=instructions,
+        )
+
+    async def add_documentation(self, file_path: str, target: str) -> Dict[str, Any]:
+        return await self._run_service(
+            self.service.aider.document_code,
+            repo_path=self.repo_path,
+            file_path=file_path,
+        )
+
+    async def explain_code(self, file_path: str, target: Optional[str] = None) -> Dict[str, Any]:
+        return await self._run_service(
+            self.service.aider.explain_code,
+            repo_path=self.repo_path,
+            file_path=file_path,
+            function_or_class_name=target,
+        )
+
+    async def write_tests(self, source_file: str, test_file: Optional[str] = None) -> Dict[str, Any]:
+        return await self._run_service(
+            self.service.aider.write_tests,
+            repo_path=self.repo_path,
+            source_file=source_file,
+            test_file=test_file,
+        )
+
+    async def run_tests(self, test_command: Optional[str] = None) -> Dict[str, Any]:
+        return await self._run_service(
+            self.service.testing.run_tests,
+            repo_path=self.repo_path,
+            test_command=test_command,
+        )
+
+    async def check_coverage(self) -> Dict[str, Any]:
+        return await self._run_service(
+            self.service.testing.run_coverage,
+            repo_path=self.repo_path,
+        )
+
+    async def git_diff(self) -> Dict[str, Any]:
+        return await self._run_service(
+            self.service.git.diff,
+            repo_path=self.repo_path,
+        )
+
+    async def git_commit(self, message: Optional[str] = None) -> Dict[str, Any]:
+        commit_msg = message or "Auto commit"
+        return await self._run_service(
+            self.service.git.commit,
+            repo_path=self.repo_path,
+            message=commit_msg,
+        )
+
+    async def git_push(self) -> Dict[str, Any]:
+        return await self._run_service(self.service.git.push, repo_path=self.repo_path)
+
+    async def create_pull_request(self, title: str, body: str) -> Dict[str, Any]:
+        if not self.service.is_github_available:
+            return {"error": "GitHub operations not available"}
+        return await self._run_service(
+            self.service.github.create_pr,
+            repo_path=self.repo_path,
+            title=title,
+            body=body,
+        )
+
+    async def merge_pull_request(self, pr_number: int) -> Dict[str, Any]:
+        if not self.service.is_github_available:
+            return {"error": "GitHub operations not available"}
+        return await self._run_service(
+            self.service.github.merge_pr,
+            repo_path=self.repo_path,
+            pr_number=pr_number,
+        )
+
+    async def read_file(self, path: str) -> Dict[str, Any]:
+        return await self._run_service(
+            self.service.files.read_file,
+            repo_path=self.repo_path,
+            file_path=path,
+        )
+
+    async def write_file(self, path: str, contents: str) -> Dict[str, Any]:
+        return await self._run_service(
+            self.service.files.write_file,
+            repo_path=self.repo_path,
+            file_path=path,
+            content=contents,
+        )
+
+    async def list_directory(self, path: str) -> Dict[str, Any]:
+        return await self._run_service(
+            self.service.files.list_directory,
+            repo_path=self.repo_path,
+            dir_path=path,
+        )
+
+    async def create_todo(self, text: str) -> Dict[str, Any]:
+        self.todos.append(text)
+        return {"todo": text}
+
+    async def snapshot_memory(self) -> Dict[str, Any]:
+        return {"todos": list(self.todos)}
+
+    async def _handle_capability_request(self, message: Message) -> None:
+        capability = message.content.get("capability")
+        data = message.content.get("data", {})
+
+        if capability == "software_command":
+            command = data.get("command")
+            if not isinstance(command, str):
+                await self.send_error(message.from_agent, "Invalid command", message.request_id)
+                return
+            result = await self._process_dev_command(command)
+        elif capability in self.intent_map:
+            result = await self._execute_function(capability, data)
+        else:
+            return
+
+        await self.send_capability_response(
+            message.from_agent, result, message.request_id, message.id
+        )
+
+    async def _handle_capability_response(self, message: Message) -> None:
+        pass

--- a/jarvis/agents/software_engineering_agent/tools/__init__.py
+++ b/jarvis/agents/software_engineering_agent/tools/__init__.py
@@ -1,0 +1,19 @@
+"""Tool schema aggregators for SoftwareEngineeringAgent."""
+
+from . import code, testing, git, github, filesystem, memory
+
+code_tools = code.tools
+testing_tools = testing.tools
+git_tools = git.tools
+github_tools = github.tools
+filesystem_tools = filesystem.tools
+memory_tools = memory.tools
+
+__all__ = [
+    "code_tools",
+    "testing_tools",
+    "git_tools",
+    "github_tools",
+    "filesystem_tools",
+    "memory_tools",
+]

--- a/jarvis/agents/software_engineering_agent/tools/code.py
+++ b/jarvis/agents/software_engineering_agent/tools/code.py
@@ -1,0 +1,83 @@
+"""Code manipulation tool stubs."""
+from typing import Any, Dict, List
+
+# Tool schema definitions
+
+tools: List[Dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "generate_function",
+            "description": "Generate a new Python function in the specified file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "spec": {"type": "string", "description": "Function specification"},
+                    "file_path": {"type": "string", "description": "File path"},
+                },
+                "required": ["spec", "file_path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "refactor_code",
+            "description": "Refactor code in a file according to instructions",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "file_path": {"type": "string"},
+                    "instructions": {"type": "string"},
+                },
+                "required": ["file_path", "instructions"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "add_documentation",
+            "description": "Add documentation to a file or function",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "file_path": {"type": "string"},
+                    "target": {"type": "string", "description": "Function or section"},
+                },
+                "required": ["file_path", "target"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "explain_code",
+            "description": "Explain selected code",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "file_path": {"type": "string"},
+                    "target": {"type": "string", "description": "Optional function or class"},
+                },
+                "required": ["file_path"],
+            },
+        },
+    },
+]
+
+
+async def generate_function(*args, **kwargs) -> str:
+    raise NotImplementedError
+
+
+async def refactor_code(*args, **kwargs) -> str:
+    raise NotImplementedError
+
+
+async def add_documentation(*args, **kwargs) -> str:
+    raise NotImplementedError
+
+
+async def explain_code(*args, **kwargs) -> str:
+    raise NotImplementedError

--- a/jarvis/agents/software_engineering_agent/tools/filesystem.py
+++ b/jarvis/agents/software_engineering_agent/tools/filesystem.py
@@ -1,0 +1,57 @@
+"""Filesystem tool stubs."""
+from typing import Any, Dict, List
+
+
+tools: List[Dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read a file's contents",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "write_file",
+            "description": "Write contents to a file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "contents": {"type": "string"},
+                },
+                "required": ["path", "contents"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_directory",
+            "description": "List directory entries",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+        },
+    },
+]
+
+
+async def read_file(*args, **kwargs) -> str:
+    raise NotImplementedError
+
+
+async def write_file(*args, **kwargs) -> str:
+    raise NotImplementedError
+
+
+async def list_directory(*args, **kwargs) -> str:
+    raise NotImplementedError

--- a/jarvis/agents/software_engineering_agent/tools/git.py
+++ b/jarvis/agents/software_engineering_agent/tools/git.py
@@ -1,0 +1,46 @@
+"""Git operation tool stubs."""
+from typing import Any, Dict, List
+
+
+tools: List[Dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "git_diff",
+            "description": "Show git diff",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "git_commit",
+            "description": "Commit staged changes",
+            "parameters": {
+                "type": "object",
+                "properties": {"message": {"type": "string"}},
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "git_push",
+            "description": "Push commits to remote",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+]
+
+
+async def git_diff(*args, **kwargs) -> str:
+    raise NotImplementedError
+
+
+async def git_commit(*args, **kwargs) -> str:
+    raise NotImplementedError
+
+
+async def git_push(*args, **kwargs) -> str:
+    raise NotImplementedError

--- a/jarvis/agents/software_engineering_agent/tools/github.py
+++ b/jarvis/agents/software_engineering_agent/tools/github.py
@@ -1,0 +1,41 @@
+"""GitHub operation tool stubs."""
+from typing import Any, Dict, List
+
+
+tools: List[Dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "create_pull_request",
+            "description": "Create a pull request",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "body": {"type": "string"},
+                },
+                "required": ["title", "body"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "merge_pull_request",
+            "description": "Merge an existing pull request",
+            "parameters": {
+                "type": "object",
+                "properties": {"pr_number": {"type": "integer"}},
+                "required": ["pr_number"],
+            },
+        },
+    },
+]
+
+
+async def create_pull_request(*args, **kwargs) -> str:
+    raise NotImplementedError
+
+
+async def merge_pull_request(*args, **kwargs) -> str:
+    raise NotImplementedError

--- a/jarvis/agents/software_engineering_agent/tools/memory.py
+++ b/jarvis/agents/software_engineering_agent/tools/memory.py
@@ -1,0 +1,34 @@
+"""Memory and logging tool stubs."""
+from typing import Any, Dict, List
+
+
+tools: List[Dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "create_todo",
+            "description": "Create a TODO item",
+            "parameters": {
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+                "required": ["text"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "snapshot_memory",
+            "description": "Snapshot agent state for later retrieval",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+]
+
+
+async def create_todo(*args, **kwargs) -> str:
+    raise NotImplementedError
+
+
+async def snapshot_memory(*args, **kwargs) -> str:
+    raise NotImplementedError

--- a/jarvis/agents/software_engineering_agent/tools/testing.py
+++ b/jarvis/agents/software_engineering_agent/tools/testing.py
@@ -1,0 +1,55 @@
+"""Testing tool stubs."""
+from typing import Any, Dict, List
+
+
+tools: List[Dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "write_tests",
+            "description": "Generate unit tests for a source file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "source_file": {"type": "string"},
+                    "test_file": {"type": "string"},
+                },
+                "required": ["source_file"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "run_tests",
+            "description": "Run the test suite",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "test_command": {"type": "string"},
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "check_coverage",
+            "description": "Check code coverage metrics",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+]
+
+
+async def write_tests(*args, **kwargs) -> str:
+    raise NotImplementedError
+
+
+async def run_tests(*args, **kwargs) -> str:
+    raise NotImplementedError
+
+
+async def check_coverage(*args, **kwargs) -> str:
+    raise NotImplementedError


### PR DESCRIPTION
## Summary
- wire SoftwareEngineeringAgent to `aider_service` operations
- expose all tool capabilities and map them via an intent table
- implement tool wrappers calling `AiderService`

## Testing
- `pip install --break-system-packages -q -r requirements.txt --no-deps`
- `python3 -m pytest -q` *(fails: ImportError for `pydantic_core`)*


------
https://chatgpt.com/codex/tasks/task_e_685850081ed0832a9f64f3d3b017e2f9