### PR TITLE
Fix jarvis shutdown

### DIFF
--- a/jarvis/main_jarvis.py
+++ b/jarvis/main_jarvis.py
@@ -352,6 +352,8 @@ class JarvisSystem:
         await self.network.stop()
         if self.calendar_service:
             await self.calendar_service.close()
+        if self.usage_logger:
+            await self.usage_logger.close()
         self.logger.log("INFO", "Jarvis system shutdown complete")
         self.logger.close()
 


### PR DESCRIPTION
## Summary
- close the Mongo logger when shutting down Jarvis

## Testing
- `pytest -q` *(fails: pyenv: version `3.11.8` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68588a8cdc2c832ab0f29777120092b8