### PR TITLE
Refactor config handling

### DIFF
--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -2,6 +2,7 @@
 
 from .services.calendar_service import CalendarService
 from .logger import JarvisLogger
+from .config import JarvisConfig
 from .log_viewer import LogViewer
 from .ai_clients import (
     AIClientFactory,
@@ -32,6 +33,7 @@ __all__ = [
     "CollaborativeCalendarAgent",
     "JarvisSystem",
     "create_collaborative_jarvis",
+    "JarvisConfig",
     "Protocol",
     "ProtocolStep",
     "ProtocolRegistry",

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class JarvisConfig:
+    """Configuration options for :class:`~jarvis.main_jarvis.JarvisSystem`."""
+
+    ai_provider: str = "openai"
+    api_key: Optional[str] = None
+    calendar_api_url: str = "http://localhost:8080"
+    repo_path: str = "."
+    response_timeout: float = 15.0


### PR DESCRIPTION
## Summary
- add `JarvisConfig` dataclass to centralize configuration
- refactor `JarvisSystem` to accept `JarvisConfig`
- expose `JarvisConfig` from package
- update FastAPI server to use typed configuration and default port

## Testing
- `pip install --break-system-packages httpx pytest pytest-asyncio pydantic motor colorama fastapi uvicorn`
- `pip install --break-system-packages openai`
- `pip install --break-system-packages anthropic`
- `pip install --break-system-packages tzlocal`
- `pyenv local 3.11.12`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685898a80e04832ab8718c9b4880f296