### PR TITLE
Add interactive demo with modular IO

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,14 @@ python server.py
 The `/jarvis` endpoint accepts a JSON body with a `command` field describing the calendar request.
 
 ## Demo script
-To try the collaborative Jarvis system from the command line:
+Run the interactive demo from the command line:
 ```bash
 python -m asyncio run main.py
 ```
-The script prompts for a natural language command and prints the agent response.
+The demo now supports multiple commands in a single session. Type your request
+and Jarvis will respond until you enter `exit`.
+Input and output handling is implemented via pluggable classes in
+`jarvis.io`, allowing future integrations with custom interfaces.
 
 ## Viewing logs
 Agent activity is stored in `jarvis_logs.db`. Launch the interactive viewer with:

--- a/jarvis/io/__init__.py
+++ b/jarvis/io/__init__.py
@@ -1,0 +1,8 @@
+from .base import InputHandler, OutputHandler, ConsoleInput, ConsoleOutput
+
+__all__ = [
+    "InputHandler",
+    "OutputHandler",
+    "ConsoleInput",
+    "ConsoleOutput",
+]

--- a/jarvis/io/base.py
+++ b/jarvis/io/base.py
@@ -1,0 +1,20 @@
+import asyncio
+
+class InputHandler:
+    async def get_input(self, prompt: str) -> str:
+        """Return user input for the given prompt."""
+        raise NotImplementedError
+
+class OutputHandler:
+    async def send_output(self, message: str) -> None:
+        """Send a message to the user."""
+        raise NotImplementedError
+
+class ConsoleInput(InputHandler):
+    async def get_input(self, prompt: str) -> str:
+        # Run blocking input in a thread so the event loop isn't blocked
+        return await asyncio.to_thread(input, prompt)
+
+class ConsoleOutput(OutputHandler):
+    async def send_output(self, message: str) -> None:
+        print(message)


### PR DESCRIPTION
## Summary
- add pluggable IO classes under `jarvis.io`
- update `main.py` to use a loop and the new IO helpers
- document multi-command demo and modular IO in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68597f33d608832aa7ba8454c39c837a