### PR TITLE
Refactor core modules for clarity

### DIFF
--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -21,6 +21,12 @@ from .protocols import Protocol, ProtocolStep
 from .protocols.registry import ProtocolRegistry
 from .protocols.executor import ProtocolExecutor
 from .protocols.builder import create_from_file
+from .constants import (
+    DEFAULT_PORT,
+    LOG_DB_PATH,
+    PROTOCOL_RESPONSES,
+    ExecutionResult,
+)
 __all__ = [
     "CalendarService",
     "AIClientFactory",
@@ -39,4 +45,8 @@ __all__ = [
     "ProtocolRegistry",
     "ProtocolExecutor",
     "create_from_file",
+    "DEFAULT_PORT",
+    "LOG_DB_PATH",
+    "PROTOCOL_RESPONSES",
+    "ExecutionResult",
 ]

--- a/jarvis/agents/base.py
+++ b/jarvis/agents/base.py
@@ -62,10 +62,14 @@ class NetworkAgent:
         self.logger.log("DEBUG", f"{self.name} unknown message", message.message_type)
 
     async def _handle_capability_request(self, message: Message) -> None:
-        pass
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must implement _handle_capability_request"
+        )
 
     async def _handle_capability_response(self, message: Message) -> None:
-        pass
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must implement _handle_capability_response"
+        )
 
     async def _handle_error(self, message: Message) -> None:
         self.logger.log("ERROR", f"Error from {message.from_agent}", message.content)

--- a/jarvis/constants.py
+++ b/jarvis/constants.py
@@ -1,0 +1,29 @@
+"""Shared constants and enumerations for Jarvis."""
+
+from enum import Enum
+
+# Default network configuration
+DEFAULT_PORT = 8000
+
+# Default SQLite database for logs
+LOG_DB_PATH = "jarvis_logs.db"
+
+# Pre-defined protocol response phrases used when summarizing protocol results
+PROTOCOL_RESPONSES = {
+    "blue_lights_on": "Blue lights activated, sir.",
+    "blue_lights_off": "Blue lights deactivated, sir.",
+    "red_alert": "Red alert mode engaged. All systems on high alert, sir.",
+    "all_lights_off": "All lights have been turned off, sir.",
+    "dim_lights": "Lights dimmed to comfortable levels, sir.",
+    "bright_lights": "Lights set to maximum brightness, sir.",
+    "morning_routine": "Good morning, sir. Your morning routine has been initiated.",
+    "goodnight": "Goodnight, sir. Sleep mode activated.",
+}
+
+
+class ExecutionResult(str, Enum):
+    """Possible results of executing a protocol."""
+
+    SUCCESS = "success"
+    PARTIAL = "partial"
+    FAILURE = "failure"

--- a/jarvis/loggers/jarvis_logger.py
+++ b/jarvis/loggers/jarvis_logger.py
@@ -1,14 +1,16 @@
 import logging
 import sqlite3
 from datetime import datetime
-from typing import Optional, Any
+from typing import Any, Optional
 import json
+
+from ..constants import LOG_DB_PATH
 
 
 class JarvisLogger:
     """Simple logger that writes to stdout and a SQLite database."""
 
-    def __init__(self, db_path: str = "jarvis_logs.db", log_level: int = logging.INFO) -> None:
+    def __init__(self, db_path: str = LOG_DB_PATH, log_level: int = logging.INFO) -> None:
         self.db_path = db_path
         self.conn: Optional[sqlite3.Connection] = None
         self.log_level = log_level

--- a/jarvis/main_jarvis.py
+++ b/jarvis/main_jarvis.py
@@ -27,18 +27,7 @@ from .protocols.executor import ProtocolExecutor
 from .protocols.loggers import ProtocolUsageLogger
 from .protocols.voice_trigger import VoiceTriggerMatcher
 from .protocols import Protocol
-
-# Pre-defined phrases used when summarizing protocol execution results.
-PROTOCOL_RESPONSES: Dict[str, str] = {
-    "blue_lights_on": "Blue lights activated, sir.",
-    "blue_lights_off": "Blue lights deactivated, sir.",
-    "red_alert": "Red alert mode engaged. All systems on high alert, sir.",
-    "all_lights_off": "All lights have been turned off, sir.",
-    "dim_lights": "Lights dimmed to comfortable levels, sir.",
-    "bright_lights": "Lights set to maximum brightness, sir.",
-    "morning_routine": "Good morning, sir. Your morning routine has been initiated.",
-    "goodnight": "Goodnight, sir. Sleep mode activated.",
-}
+from .constants import PROTOCOL_RESPONSES
 
 
 class JarvisSystem:

--- a/jarvis/protocols/executor.py
+++ b/jarvis/protocols/executor.py
@@ -8,6 +8,7 @@ import time
 
 from ..logger import JarvisLogger
 from ..agents.agent_network import AgentNetwork
+from ..constants import ExecutionResult
 from . import Protocol
 from .loggers import ProtocolUsageLogger, generate_protocol_log
 
@@ -114,10 +115,12 @@ class ProtocolExecutor:
         errors = [r for r in results.values() if isinstance(r, dict) and "error" in r]
         if errors:
             execution_result = (
-                "partial" if len(errors) < len(protocol.steps) else "failure"
+                ExecutionResult.PARTIAL
+                if len(errors) < len(protocol.steps)
+                else ExecutionResult.FAILURE
             )
         else:
-            execution_result = "success"
+            execution_result = ExecutionResult.SUCCESS
 
         latency_ms = int((time.monotonic() - start) * 1000)
 
@@ -128,7 +131,7 @@ class ProtocolExecutor:
                 trigger_phrase,
                 {
                     **(metadata or {}),
-                    "execution_result": execution_result,
+                    "execution_result": execution_result.value,
                     "latency_ms": latency_ms,
                 },
             )

--- a/server.py
+++ b/server.py
@@ -8,9 +8,8 @@ from pydantic import BaseModel
 from dotenv import load_dotenv
 
 from jarvis import JarvisLogger, JarvisSystem, JarvisConfig
+from jarvis.constants import DEFAULT_PORT
 from jarvis.utils import detect_timezone
-
-DEFAULT_PORT = 8000
 
 app = FastAPI(title="Jarvis API")
 


### PR DESCRIPTION
## Summary
- centralize constants and enums in new module
- use constants across the codebase
- expose constants in public API
- strengthen `NetworkAgent` base implementation
- use `ExecutionResult` enum in protocol executor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68598132bd0c832ab6f7586b1f23b0fe