### PR TITLE
Introduce weak and strong chat methods

### DIFF
--- a/jarvis/agents/calendar_agent/__init__.py
+++ b/jarvis/agents/calendar_agent/__init__.py
@@ -207,7 +207,7 @@ class CollaborativeCalendarAgent(NetworkAgent):
         MAX_ITERATIONS = 10  # Increased for complex operations
         tool_calls = None
         while iterations < MAX_ITERATIONS:
-            message, tool_calls = await self.ai_client.chat(messages, self.tools)
+            message, tool_calls = await self.ai_client.strong_chat(messages, self.tools)
             self.logger.log(
                 "INFO", "AI response", getattr(message, "content", str(message))
             )

--- a/jarvis/agents/chat_agent/__init__.py
+++ b/jarvis/agents/chat_agent/__init__.py
@@ -139,7 +139,7 @@ class ChatAgent(NetworkAgent):
                 {"role": "user", "content": user_message},
             ]
 
-            response, _ = await self.ai_client.chat(messages, [])
+            response, _ = await self.ai_client.strong_chat(messages, [])
 
             # Add response to history
             self.conversation_history[-1]["assistant"] = response.content
@@ -162,7 +162,7 @@ class ChatAgent(NetworkAgent):
             Format: Just return the joke, nothing else."""
 
             messages = [{"role": "user", "content": joke_prompt}]
-            response, _ = await self.ai_client.chat(messages, [])
+            response, _ = await self.ai_client.strong_chat(messages, [])
 
             return {"response": f"Here's one for you: {response.content}"}
 
@@ -185,7 +185,7 @@ class ChatAgent(NetworkAgent):
             Make it engaging and end with a question to continue the story if they want."""
 
             messages = [{"role": "user", "content": story_prompt}]
-            response, _ = await self.ai_client.chat(messages, [])
+            response, _ = await self.ai_client.strong_chat(messages, [])
 
             return {"response": response.content}
 
@@ -247,7 +247,7 @@ class ChatAgent(NetworkAgent):
             Be supportive, wise, and actionable. Consider multiple perspectives and be encouraging."""
 
             messages = [{"role": "user", "content": advice_prompt}]
-            response, _ = await self.ai_client.chat(messages, [])
+            response, _ = await self.ai_client.strong_chat(messages, [])
 
             return {"response": response.content}
 
@@ -265,7 +265,7 @@ class ChatAgent(NetworkAgent):
             Make it interesting and engaging, like something JARVIS would find noteworthy."""
 
             messages = [{"role": "user", "content": fact_prompt}]
-            response, _ = await self.ai_client.chat(messages, [])
+            response, _ = await self.ai_client.strong_chat(messages, [])
 
             return {"response": f"Here's something interesting: {response.content}"}
 
@@ -286,7 +286,7 @@ class ChatAgent(NetworkAgent):
             Format: Present the riddle and ask them to guess. Don't give the answer yet."""
 
             messages = [{"role": "user", "content": riddle_prompt}]
-            response, _ = await self.ai_client.chat(messages, [])
+            response, _ = await self.ai_client.strong_chat(messages, [])
 
             return {"response": response.content}
 
@@ -320,7 +320,7 @@ class ChatAgent(NetworkAgent):
                 Be uplifting, practical, and inspiring. Focus on their potential and next steps."""
 
                 messages = [{"role": "user", "content": motivate_prompt}]
-                response, _ = await self.ai_client.chat(messages, [])
+                response, _ = await self.ai_client.strong_chat(messages, [])
 
                 return {"response": response.content}
             else:
@@ -426,7 +426,7 @@ class ChatAgent(NetworkAgent):
             Format: Question followed by multiple choice options (A, B, C, D). Don't give the answer yet."""
 
             messages = [{"role": "user", "content": trivia_prompt}]
-            response, _ = await self.ai_client.chat(messages, [])
+            response, _ = await self.ai_client.strong_chat(messages, [])
 
             return {"response": response.content}
 

--- a/jarvis/agents/lights_agent/__init__.py
+++ b/jarvis/agents/lights_agent/__init__.py
@@ -938,7 +938,7 @@ class PhillipsHueAgent(NetworkAgent):
                 "INFO", f"=== ITERATION {iterations + 1} ===", "Sending request to AI"
             )
 
-            message, tool_calls = await self.ai_client.chat(messages, self.tools)
+            message, tool_calls = await self.ai_client.strong_chat(messages, self.tools)
 
             self.logger.log(
                 "INFO",

--- a/jarvis/agents/nlu_agent/__init__.py
+++ b/jarvis/agents/nlu_agent/__init__.py
@@ -102,7 +102,7 @@ class NLUAgent(NetworkAgent):
         prompt = self.build_prompt(user_input, capabilities)
         self.logger.log("DEBUG", "NLU prompt built", prompt)
 
-        response = await self.ai_client.chat(
+        response = await self.ai_client.weak_chat(
             [
                 {"role": "system", "content": prompt},
                 {"role": "user", "content": user_input},

--- a/jarvis/agents/orchestrator_agent/__init__.py
+++ b/jarvis/agents/orchestrator_agent/__init__.py
@@ -417,7 +417,7 @@ Make sure the result enables deterministic scheduling and coordination between a
             {"role": "user", "content": user_input},
         ]
 
-        response = await self.ai_client.chat(messages, [])
+        response = await self.ai_client.strong_chat(messages, [])
         self.logger.log(
             "DEBUG",
             "Analysis raw response",
@@ -482,5 +482,5 @@ RESPONSE STYLE:
             },
         ]
 
-        result = await self.ai_client.chat(messages, [])
+        result = await self.ai_client.strong_chat(messages, [])
         return result[0].content

--- a/jarvis/ai_clients/anthropic_client.py
+++ b/jarvis/ai_clients/anthropic_client.py
@@ -11,16 +11,36 @@ from .base import BaseAIClient
 class AnthropicClient(BaseAIClient):
     """AI client that delegates requests to Anthropic's API."""
 
-    def __init__(self, api_key: str | None = None, model: str = "claude-3-opus-20240229") -> None:
-        self.client = anthropic.AsyncAnthropic(api_key=api_key or os.environ.get("ANTHROPIC_API_KEY"))
-        self.model = model
+    def __init__(
+        self,
+        api_key: str | None = None,
+        strong_model: str = "claude-3-opus-20240229",
+        weak_model: str = "claude-3-haiku-20240307",
+    ) -> None:
+        self.client = anthropic.AsyncAnthropic(
+            api_key=api_key or os.environ.get("ANTHROPIC_API_KEY")
+        )
+        self.strong_model = strong_model
+        self.weak_model = weak_model
 
-    async def chat(self, messages: List[Dict[str, Any]], tools: List[Dict[str, Any]]) -> Tuple[Any, Any]:
+    async def _chat(
+        self, messages: List[Dict[str, Any]], model: str
+    ) -> Tuple[Any, Any]:
         response = await self.client.messages.create(
-            model=self.model,
+            model=model,
             messages=messages,
             system="",
             max_tokens=1000,
         )
         message = response
         return message, []  # tool calls not implemented for Anthropic yet
+
+    async def strong_chat(
+        self, messages: List[Dict[str, Any]], tools: List[Dict[str, Any]] | None = None
+    ) -> Tuple[Any, Any]:
+        return await self._chat(messages, self.strong_model)
+
+    async def weak_chat(
+        self, messages: List[Dict[str, Any]], tools: List[Dict[str, Any]] | None = None
+    ) -> Tuple[Any, Any]:
+        return await self._chat(messages, self.weak_model)

--- a/jarvis/ai_clients/base.py
+++ b/jarvis/ai_clients/base.py
@@ -8,6 +8,15 @@ class BaseAIClient(ABC):
     """Abstract base class defining the interface for chat-based AI models."""
 
     @abstractmethod
-    async def chat(self, messages: List[Dict[str, Any]], tools: List[Dict[str, Any]]) -> Tuple[Any, Any]:
-        """Send chat messages with optional tools and return response and tool calls."""
+    async def strong_chat(
+        self, messages: List[Dict[str, Any]], tools: List[Dict[str, Any]] | None = None
+    ) -> Tuple[Any, Any]:
+        """High quality chat using more capable (and expensive) models."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def weak_chat(
+        self, messages: List[Dict[str, Any]], tools: List[Dict[str, Any]] | None = None
+    ) -> Tuple[Any, Any]:
+        """Lower quality chat for lightweight tasks."""
         raise NotImplementedError

--- a/jarvis/ai_clients/dummy_client.py
+++ b/jarvis/ai_clients/dummy_client.py
@@ -8,6 +8,14 @@ from .base import BaseAIClient
 class DummyAIClient(BaseAIClient):
     """Simple AI client that returns a canned response without network calls."""
 
-    async def chat(self, messages: List[Dict[str, Any]], tools: List[Dict[str, Any]] | None = None) -> Tuple[Any, Any]:
+    async def strong_chat(
+        self, messages: List[Dict[str, Any]], tools: List[Dict[str, Any]] | None = None
+    ) -> Tuple[Any, Any]:
+        response = {"content": "This is a dummy response."}
+        return type("Message", (), response), None
+
+    async def weak_chat(
+        self, messages: List[Dict[str, Any]], tools: List[Dict[str, Any]] | None = None
+    ) -> Tuple[Any, Any]:
         response = {"content": "This is a dummy response."}
         return type("Message", (), response), None


### PR DESCRIPTION
## Summary
- define `weak_chat` and `strong_chat` in `BaseAIClient`
- implement both methods for OpenAI, Anthropic and dummy clients
- use `weak_chat` in `NLUAgent`
- switch other agents to `strong_chat`
- update tests for new AI client interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685981f9953c832a8dc78bb020a30179