### PR TITLE
Ensure ChatAgent sends capability responses

### DIFF
--- a/jarvis/agents/chat_agent/__init__.py
+++ b/jarvis/agents/chat_agent/__init__.py
@@ -84,9 +84,13 @@ class ChatAgent(NetworkAgent):
         try:
             if capability in self.function_map:
                 user_input = data.get("message", data.get("command", ""))
-                return await self.function_map[capability](user_input)
+                result = await self.function_map[capability](user_input)
             else:
-                return await self._handle_chat(data.get("command", ""))
+                result = await self._handle_chat(data.get("command", ""))
+
+            await self.send_capability_response(
+                message.from_agent, result, message.request_id, message.id
+            )
 
         except Exception as exc:
             self.logger.log("ERROR", f"ChatAgent error handling {capability}", str(exc))


### PR DESCRIPTION
## Summary
- fix `_handle_capability_request` in ChatAgent to always send replies using `send_capability_response`
- keep error branch unchanged

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685989641084832ab9d6fc02e36aa1ed