### PR TITLE
Add latency tracing for voice pipeline

### DIFF
--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -14,4 +14,6 @@ class JarvisConfig:
     calendar_api_url: str = "http://localhost:8080"
     repo_path: str = "."
     response_timeout: float = 15.0
-    perf_tracking: bool = os.getenv("PERF_TRACKING", "false").lower() == "true"
+    perf_tracking: bool = os.getenv(
+        "PERF_TRACE", os.getenv("PERF_TRACKING", "false")
+    ).lower() == "true"

--- a/jarvis/io/input/transcription/openai_whisper.py
+++ b/jarvis/io/input/transcription/openai_whisper.py
@@ -39,7 +39,7 @@ class OpenAISTTEngine(SpeechToTextEngine):
         self.silence_threshold = silence_threshold
         self.silence_duration = silence_duration
 
-    @track_async("speech_transcription")
+    @track_async("stt")
     async def listen_for_speech(self, timeout: float = 10.0) -> str:
         """Listen for speech and return transcribed text."""
         try:

--- a/jarvis/io/output/tts/openai.py
+++ b/jarvis/io/output/tts/openai.py
@@ -8,7 +8,7 @@ import openai
 from ...utils.audio import play_audio_bytes
 from ....logger import JarvisLogger
 from .base import TextToSpeechEngine
-from ....performance import track_async
+from ....performance import get_tracker
 
 
 class OpenAITTSEngine(TextToSpeechEngine):
@@ -30,14 +30,26 @@ class OpenAITTSEngine(TextToSpeechEngine):
         self.voice = voice
         self.client = openai.AsyncOpenAI(api_key=self.api_key)
 
-    @track_async("tts_synthesis")
     async def speak(self, text: str) -> None:  # noqa: D401 - interface impl
         """Convert ``text`` to speech and play it asynchronously."""
+        tracker = get_tracker()
         try:
-            response = await self.client.audio.speech.create(
-                model=self.model, voice=self.voice, input=text
-            )
-            audio_bytes = await response.read()
-            await asyncio.to_thread(play_audio_bytes, audio_bytes)
+            if tracker and tracker.enabled:
+                async with tracker.timer("tts_synthesis"):
+                    response = await self.client.audio.speech.create(
+                        model=self.model, voice=self.voice, input=text
+                    )
+                    audio_bytes = await response.read()
+            else:
+                response = await self.client.audio.speech.create(
+                    model=self.model, voice=self.voice, input=text
+                )
+                audio_bytes = await response.read()
+
+            if tracker and tracker.enabled:
+                async with tracker.timer("audio_playback"):
+                    await asyncio.to_thread(play_audio_bytes, audio_bytes)
+            else:
+                await asyncio.to_thread(play_audio_bytes, audio_bytes)
         except Exception as exc:  # pragma: no cover - network errors
             self.logger.log("ERROR", "OpenAI TTS error", str(exc))


### PR DESCRIPTION
## Summary
- implement PerfTracker with timestamps and context metadata
- hook performance timers into voice input and Jarvis main logic
- time STT, TTS and agent execution steps with `audio_playback` events
- expose config flag `PERF_TRACE` for enabling instrumentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6859b2959de8832aa7b9b3e13738f5bc