### PR TITLE
Add Vosk voice listener framework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Additional Python packages used by the project:
 - `pytest-asyncio`
 - `pymongo`
 - `pvporcupine`
+- `vosk`
 
 ## Overview
 - **Language**: Python 3.11+

--- a/jarvis/io/voice/__init__.py
+++ b/jarvis/io/voice/__init__.py
@@ -1,0 +1,18 @@
+"""Voice input listeners and registry."""
+
+from .base import VoiceInputInterface
+from .registry import VoiceInputRegistry
+from .vosk_listener import VoskVoiceListener
+
+# Import default listener registrations
+try:  # pragma: no cover - optional deps
+    from . import listeners
+except Exception:
+    listeners = None
+
+
+def input(name: str) -> VoiceInputInterface:
+    """Create a registered voice listener by ``name``."""
+    return VoiceInputRegistry.create(name)
+
+__all__ = ["VoiceInputInterface", "VoiceInputRegistry", "VoskVoiceListener", "input"]

--- a/jarvis/io/voice/base.py
+++ b/jarvis/io/voice/base.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import AsyncIterator
+
+
+class VoiceInputInterface(ABC):
+    """Abstract base for microphone listeners yielding transcription chunks."""
+
+    @abstractmethod
+    async def listen(self) -> AsyncIterator[str]:
+        """Yield transcribed text chunks until a final result is produced."""
+        raise NotImplementedError

--- a/jarvis/io/voice/listeners/__init__.py
+++ b/jarvis/io/voice/listeners/__init__.py
@@ -1,0 +1,6 @@
+"""Preconfigured Vosk voice listeners."""
+
+from . import vosk_small  # noqa: F401
+from . import vosk_lgraph  # noqa: F401
+
+__all__ = ["vosk_small", "vosk_lgraph"]

--- a/jarvis/io/voice/listeners/vosk_lgraph.py
+++ b/jarvis/io/voice/listeners/vosk_lgraph.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+
+from ..registry import VoiceInputRegistry
+from ..vosk_listener import VoskVoiceListener
+
+MODEL_PATH = os.path.join("models", "vosk-model-en-us-0.22-lgraph")
+
+
+def _factory() -> VoskVoiceListener:
+    return VoskVoiceListener(MODEL_PATH, model_name="vosk-lgraph")
+
+
+VoiceInputRegistry.register("vosk-lgraph", _factory)

--- a/jarvis/io/voice/listeners/vosk_small.py
+++ b/jarvis/io/voice/listeners/vosk_small.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import os
+from functools import partial
+
+from ..registry import VoiceInputRegistry
+from ..vosk_listener import VoskVoiceListener
+
+MODEL_PATH = os.path.join("models", "vosk-model-small-en-us-0.15")
+
+
+def _factory() -> VoskVoiceListener:
+    return VoskVoiceListener(MODEL_PATH, model_name="vosk-small")
+
+
+VoiceInputRegistry.register("vosk-small", _factory)

--- a/jarvis/io/voice/registry.py
+++ b/jarvis/io/voice/registry.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, List
+
+from .base import VoiceInputInterface
+
+
+class VoiceInputRegistry:
+    """Registry for named voice input listeners."""
+
+    _registry: Dict[str, Callable[[], VoiceInputInterface]] = {}
+
+    @classmethod
+    def register(cls, name: str, factory: Callable[[], VoiceInputInterface]) -> None:
+        cls._registry[name] = factory
+
+    @classmethod
+    def create(cls, name: str) -> VoiceInputInterface:
+        if name not in cls._registry:
+            raise KeyError(f"Unknown voice listener '{name}'")
+        return cls._registry[name]()
+
+    @classmethod
+    def available(cls) -> List[str]:
+        return list(cls._registry.keys())

--- a/jarvis/io/voice/vosk_listener.py
+++ b/jarvis/io/voice/vosk_listener.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import queue
+from typing import AsyncIterator, List, Optional
+
+import sounddevice as sd
+import vosk
+from colorama import Fore, Style
+
+from .base import VoiceInputInterface
+
+
+class VoskVoiceListener(VoiceInputInterface):
+    """Real-time speech recognition using a Vosk model."""
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        sample_rate: int = 16000,
+        chunk_size: int = 8000,
+        model_name: str = "vosk",
+        grammar: Optional[List[str]] = None,
+        debug: bool = True,
+        device: Optional[int] = None,
+    ) -> None:
+        self.model_path = model_path
+        self.sample_rate = sample_rate
+        self.chunk_size = chunk_size
+        self.model_name = model_name
+        self.grammar = grammar
+        self.debug = debug
+        self.device = device
+        self.model = vosk.Model(model_path)
+
+    def set_grammar(self, phrases: List[str]) -> None:
+        """Update recognizer grammar phrases."""
+        self.grammar = phrases
+
+    async def listen(self) -> AsyncIterator[str]:  # noqa: D401
+        """Yield transcription chunks from microphone input."""
+        audio_q: queue.Queue[bytes] = queue.Queue()
+
+        def callback(indata, frames, time, status):
+            if status and self.debug:
+                print(f"[{self.model_name}] {status}")
+            audio_q.put(bytes(indata))
+
+        recognizer = vosk.KaldiRecognizer(self.model, self.sample_rate)
+        recognizer.SetWords(True)
+        if self.grammar:
+            recognizer.SetGrammar(json.dumps(self.grammar))
+
+        stream = sd.RawInputStream(
+            samplerate=self.sample_rate,
+            blocksize=self.chunk_size,
+            dtype="int16",
+            channels=1,
+            callback=callback,
+            device=self.device,
+        )
+
+        last_partial = ""
+        with stream:
+            try:
+                while True:
+                    data = await asyncio.to_thread(audio_q.get)
+                    if recognizer.AcceptWaveform(data):
+                        result = json.loads(recognizer.Result())
+                        text = result.get("text", "")
+                        if text:
+                            if self.debug:
+                                print(Fore.GREEN + text + Style.RESET_ALL)
+                            yield text
+                        break
+                    else:
+                        partial = json.loads(recognizer.PartialResult()).get(
+                            "partial", ""
+                        )
+                        if partial and partial != last_partial:
+                            last_partial = partial
+                            if self.debug:
+                                print(Fore.CYAN + partial + Style.RESET_ALL)
+                            yield partial
+            except KeyboardInterrupt:
+                if self.debug:
+                    print("\nStopping voice listener")
+            finally:
+                if self.debug:
+                    print("Listener exited")

--- a/requirements.txt
+++ b/requirements.txt
@@ -131,3 +131,4 @@ zipp
 phue
 colorama
 pvporcupine
+vosk


### PR DESCRIPTION
## Summary
- implement a voice subsystem with a registry
- add a `VoskVoiceListener` supporting partial and final transcript updates
- register preconfigured small and lgraph listeners
- document new `vosk` dependency

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3d88bb18832abc86bef9970944a0