### PR TITLE
Fix exact trigger matching

### DIFF
--- a/jarvis/protocols/voice_trigger.py
+++ b/jarvis/protocols/voice_trigger.py
@@ -65,7 +65,7 @@ class ParameterizedProtocol:
         normalized_input = user_input.strip()
 
         for pattern, placeholders, original_phrase in self.patterns:
-            match = pattern.search(normalized_input)
+            match = pattern.fullmatch(normalized_input)
             if match:
                 # Extract arguments
                 arguments = {}
@@ -170,14 +170,7 @@ class VoiceTriggerMatcher:
                 "matched_phrase": normalized,
             }
 
-        # Try partial matches for simple triggers
-        for trigger, protocol in self.simple_triggers.items():
-            if trigger in normalized:
-                return {
-                    "protocol": protocol,
-                    "arguments": {},
-                    "matched_phrase": trigger,
-                }
+        # Partial matching is disabled to avoid accidental activations
 
         return None
 

--- a/tests/test_voice_trigger.py
+++ b/tests/test_voice_trigger.py
@@ -1,0 +1,53 @@
+import pytest
+
+from jarvis.protocols.voice_trigger import VoiceTriggerMatcher
+from jarvis.protocols.models.protocol import Protocol
+from jarvis.protocols.models.argument_definition import ArgumentDefinition, ArgumentType
+
+
+def make_color_protocol():
+    arg_def = ArgumentDefinition(
+        name="color",
+        type=ArgumentType.CHOICE,
+        choices=["red", "blue"],
+    )
+    return Protocol(
+        id="1",
+        name="Light Color",
+        description="",
+        trigger_phrases=["lights {color}"],
+        steps=[],
+        argument_definitions=[arg_def],
+    )
+
+
+def make_simple_protocol():
+    return Protocol(
+        id="2",
+        name="Shutdown",
+        description="",
+        trigger_phrases=["shutdown system"],
+        steps=[],
+    )
+
+
+def test_exact_match_required_for_parameterized():
+    proto = make_color_protocol()
+    matcher = VoiceTriggerMatcher({proto.id: proto})
+
+    result = matcher.match_command("lights red")
+    assert result is not None
+    assert result["arguments"]["color"] == "red"
+
+    assert matcher.match_command("please lights red") is None
+
+
+def test_exact_match_required_for_simple():
+    proto = make_simple_protocol()
+    matcher = VoiceTriggerMatcher({proto.id: proto})
+
+    result = matcher.match_command("shutdown system")
+    assert result is not None
+    assert result["protocol"] == proto
+
+    assert matcher.match_command("please shutdown system") is None


### PR DESCRIPTION
## Summary
- ensure parameterized protocol regex uses `fullmatch`
- remove partial matching fallback
- test VoiceTriggerMatcher matching

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5d90b0d4832a98327638935103f7