### PR TITLE
Improve Jarvis protocol responses

### DIFF
--- a/jarvis/constants.py
+++ b/jarvis/constants.py
@@ -9,15 +9,43 @@ DEFAULT_PORT = 8000
 LOG_DB_PATH = "jarvis_logs.db"
 
 # Pre-defined protocol response phrases used when summarizing protocol results
+# These names must match the protocol definitions exactly
 PROTOCOL_RESPONSES = {
-    "blue_lights_on": "Blue lights activated, sir.",
-    "blue_lights_off": "Blue lights deactivated, sir.",
-    "red_alert": "Red alert mode engaged. All systems on high alert, sir.",
-    "all_lights_off": "All lights have been turned off, sir.",
-    "dim_lights": "Lights dimmed to comfortable levels, sir.",
-    "bright_lights": "Lights set to maximum brightness, sir.",
-    "morning_routine": "Good morning, sir. Your morning routine has been initiated.",
-    "goodnight": "Goodnight, sir. Sleep mode activated.",
+    "lights_on": [
+        "All systems bright and ready, sir.",
+        "Illuminating the manor, sir.",
+        "Every light is now on, sir.",
+    ],
+    "lights_off": [
+        "Lights out. Going dark, sir.",
+        "Darkness engaged across the house, sir.",
+        "Every light has been powered down, sir.",
+    ],
+    "Dim All Lights": [
+        "Soft mood lighting in effect, sir.",
+        "Light levels reduced for a calm ambience, sir.",
+        "Dimming the house to a gentle glow, sir.",
+    ],
+    "Brighten All Lights": [
+        "Maximizing illumination, sir.",
+        "Lights set to full brilliance, sir.",
+        "Raising brightness all the way, sir.",
+    ],
+    "Flash All Lights": [
+        "Executing rapid flash sequence, sir.",
+        "All lights flashing for attention, sir.",
+        "Commencing strobe effect, sir.",
+    ],
+    "Light Color Control": [
+        "Setting all lights to {color}, sir.",
+        "The house now glows {color}, sir.",
+        "Lights adjusted to a {color} hue, sir.",
+    ],
+    "Get Today's Events": [
+        "Here's today's agenda, sir.",
+        "Allow me to present your schedule for today, sir.",
+        "These are your planned events for today, sir.",
+    ],
 }
 
 


### PR DESCRIPTION
## Summary
- refresh protocol response table based on default protocol definitions
- support argument placeholders in responses
- include arguments when formatting protocol reply

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686316073e3c832a98fa4a9304b170c0