### PR TITLE
Fix vector memory and update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ mslex
 multidict
 networkx
 numpy
-openai
+openai==1.91.0
 oslex
 packaging
 pathspec
@@ -90,6 +90,7 @@ pypandoc
 pyparsing
 pyperclip
 pytest
+pytest-asyncio
 python-dateutil
 python-dotenv
 PyYAML


### PR DESCRIPTION
## Summary
- use persistent Chroma client for vector memory
- pin `openai` to the newer API and add `pytest-asyncio`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68631f3e8f2c832aae2a40bd1c47b172