### PR TITLE
Add protocols listing API route

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ python server.py
 ```
 
 The `/jarvis` endpoint accepts a JSON body with a `command` field describing the calendar request.
+The `/protocols` endpoint returns all registered protocols and their details as JSON.
 
 ## Demo script
 

--- a/server.py
+++ b/server.py
@@ -71,6 +71,15 @@ async def jarvis(
     return await jarvis_system.process_request(req.command, tz_name, metadata)
 
 
+@app.get("/protocols")
+async def list_protocols(
+    jarvis_system: JarvisSystem = Depends(get_jarvis),
+):
+    """Return all registered protocols with their details."""
+    protocols = [p.to_dict() for p in jarvis_system.protocol_registry.protocols.values()]
+    return {"protocols": protocols}
+
+
 def run():
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=DEFAULT_PORT)

--- a/tests/test_protocol_route.py
+++ b/tests/test_protocol_route.py
@@ -1,0 +1,19 @@
+import pytest
+
+from server import list_protocols
+from jarvis.protocols.registry import ProtocolRegistry
+from jarvis.protocols import Protocol
+
+class DummyJarvis:
+    def __init__(self, registry):
+        self.protocol_registry = registry
+
+@pytest.mark.asyncio
+async def test_list_protocols(tmp_path):
+    registry = ProtocolRegistry(db_path=str(tmp_path / "db.sqlite"))
+    proto = Protocol(id="1", name="Test", description="", steps=[])
+    registry.register(proto)
+    jarvis = DummyJarvis(registry)
+    result = await list_protocols(jarvis)
+    assert result["protocols"][0]["id"] == "1"
+    assert result["protocols"][0]["name"] == "Test"

--- a/tests/test_weather_agent.py
+++ b/tests/test_weather_agent.py
@@ -1,17 +1,28 @@
 import pytest
+import asyncio
 
 from jarvis.agents.weather_agent import WeatherAgent
 from jarvis.agents.message import Message
+from jarvis.ai_clients.base import BaseAIClient
+
+
+class DummyAIClient(BaseAIClient):
+    async def strong_chat(self, messages, tools=None):
+        return None, None
+
+    async def weak_chat(self, messages, tools=None):
+        return None, None
 
 class MockResponse:
-    def __init__(self, data):
+    def __init__(self, data, status_code=200):
         self._data = data
+        self.status_code = status_code
     def json(self):
         return self._data
 
 @pytest.mark.asyncio
 async def test_get_current_weather(monkeypatch):
-    agent = WeatherAgent(api_key="key")
+    agent = WeatherAgent(ai_client=DummyAIClient(), api_key="key")
     async def mock_get(url, params=None):
         assert "weather" in url
         assert params["q"] == "London"
@@ -21,16 +32,18 @@ async def test_get_current_weather(monkeypatch):
             "main": {"temp": 25}
         })
     monkeypatch.setattr(agent.client, "get", mock_get)
-    result = await agent.get_current_weather("London")
-    assert result == {"location": "London", "temperature": 25, "description": "sunny"}
+    result = await asyncio.to_thread(agent._get_current_weather, "London")
+    assert result["location"] == "London"
+    assert result["temperature"] == 25
+    assert result["description"] == "Sunny"
 
 @pytest.mark.asyncio
 async def test_handle_request(monkeypatch):
-    agent = WeatherAgent(api_key="key")
-    async def fake_get_current_weather(loc):
-        return {"location": loc, "temperature": 10, "description": "cloudy"}
+    agent = WeatherAgent(ai_client=DummyAIClient(), api_key="key")
+    async def fake_process(cmd):
+        return {"location": "Paris", "temperature": 10, "description": "cloudy"}
 
-    monkeypatch.setattr(agent, "get_current_weather", fake_get_current_weather)
+    monkeypatch.setattr(agent, "_process_weather_command", fake_process)
     captured = {}
     async def fake_send(to, result, request_id, msg_id):
         captured["result"] = result
@@ -41,7 +54,7 @@ async def test_handle_request(monkeypatch):
         from_agent="tester",
         to_agent="WeatherAgent",
         message_type="capability_request",
-        content={"capability": "get_current_weather", "data": {"location": "Paris"}},
+        content={"capability": "weather_command", "data": {"command": "Paris"}},
         request_id="1"
     )
     await agent._handle_capability_request(message)


### PR DESCRIPTION
## Summary
- expose `/protocols` API endpoint
- document the new endpoint in README
- test the listing route
- update weather agent tests for new interface

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686561b4a9b0832abb9e232733c77787