### PR TITLE
Fix calendar agent imports and expose server API

### DIFF
--- a/jarvis/agents/calendar_agent/agent.py
+++ b/jarvis/agents/calendar_agent/agent.py
@@ -9,7 +9,10 @@ from ...ai_clients import BaseAIClient
 from ...logger import JarvisLogger
 from .function_registry import CalendarFunctionRegistry
 from .command_processor import CalendarCommandProcessor
-from .tools import tools as calendar_tools
+# Import the tools list explicitly from the tools module. Using
+# `from .tools import tools` would import the submodule instead of the
+# variable due to Python's import resolution order.
+from .tools.tools import tools as calendar_tools
 
 
 class CollaborativeCalendarAgent(NetworkAgent):

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,12 @@
+from importlib import import_module
+
+# Re-export key objects from the legacy `server2` module for backwards
+# compatibility with tests that import from `server`.
+_server2 = import_module("server2")
+
+app = _server2.app
+pwd_context = getattr(_server2, "pwd_context", None)
+get_jarvis = _server2.get_jarvis
+list_protocols = _server2.list_protocols
+
+__all__ = ["app", "pwd_context", "get_jarvis", "list_protocols"]

--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -4,9 +4,9 @@ import sqlite3
 from fastapi import APIRouter, Request, Depends
 from fastapi.responses import JSONResponse
 
-from models import AuthRequest
-from dependencies import get_auth_db
-from auth import create_token, decode_token, hash_password, verify_password
+from ..models import AuthRequest
+from ..dependencies import get_auth_db
+from ..auth import create_token, decode_token, hash_password, verify_password
 
 
 router = APIRouter()

--- a/server/routers/jarvis.py
+++ b/server/routers/jarvis.py
@@ -11,8 +11,8 @@ from fastapi import APIRouter, Request, Depends
 from jarvis import JarvisSystem
 from jarvis.utils import detect_timezone
 
-from models import JarvisRequest
-from dependencies import get_jarvis
+from ..models import JarvisRequest
+from ..dependencies import get_jarvis
 
 
 router = APIRouter()

--- a/server/routers/protocols.py
+++ b/server/routers/protocols.py
@@ -11,8 +11,8 @@ from fastapi import APIRouter, HTTPException, Depends
 from jarvis import JarvisSystem
 from jarvis.protocols import Protocol
 
-from models import ProtocolRunRequest
-from dependencies import get_jarvis
+from ..models import ProtocolRunRequest
+from ..dependencies import get_jarvis
 
 
 router = APIRouter()


### PR DESCRIPTION
## Summary
- fix CalendarAgent importing the tools list
- expose server objects for tests
- update router imports to be package-relative

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877601fa570832aa82e76ab4d48e9da