### PR TITLE
Add helper script for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ make install
 make test
 ```
 
+Or run the helper script which creates a virtual environment and installs
+dependencies automatically:
+
+```bash
+./scripts/run_tests.sh
+```
+
 With Poetry:
 
 ```bash

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Set up virtual environment and run the test suite
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pytest


### PR DESCRIPTION
## Summary
- provide `scripts/run_tests.sh` for running tests in a venv
- document the new script in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6877ddf37a8c832aa2323dc6492b1466