### PR TITLE
Add protocol response metadata

### DIFF
--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -25,7 +25,6 @@ from .protocols.builder import create_from_file
 from .constants import (
     DEFAULT_PORT,
     LOG_DB_PATH,
-    PROTOCOL_RESPONSES,
     ExecutionResult,
 )
 from .performance import PerfTracker, track_async
@@ -54,7 +53,6 @@ __all__ = [
     "create_from_file",
     "DEFAULT_PORT",
     "LOG_DB_PATH",
-    "PROTOCOL_RESPONSES",
     "ExecutionResult",
     "PerfTracker",
     "track_async",

--- a/jarvis/constants.py
+++ b/jarvis/constants.py
@@ -8,93 +8,6 @@ DEFAULT_PORT = 8000
 # Default SQLite database for logs
 LOG_DB_PATH = "jarvis_logs.db"
 
-# Pre-defined protocol response phrases used when summarizing protocol results
-PROTOCOL_RESPONSES = {
-    "lights_on": [
-        "All lights have been successfully activated, sir.",
-        "The entire residence is now fully illuminated, sir.",
-        "Lighting systems are online, as requested, sir.",
-        "I've restored full illumination to the manor, sir.",
-        "Every light in the building has been switched on, sir.",
-        "The manor's lighting grid is fully operational, sir.",
-        "All ambient lights are active now, sir.",
-        "Lights powered up and ready for your convenience, sir.",
-        "Full lighting mode engaged throughout the premises, sir.",
-        "The lighting systems are functioning at full capacity, sir.",
-    ],
-    "lights_off": [
-        "All lighting systems have been disengaged, sir.",
-        "The manor is now darkened, sir.",
-        "Lighting has been powered down completely, sir.",
-        "Dark mode successfully initiated across the residence, sir.",
-        "I've disabled all illumination, sir.",
-        "The residence is in blackout mode, sir.",
-        "All lights have been extinguished, sir.",
-        "Illumination protocols have been terminated, sir.",
-        "I've placed the house into low-power darkness mode, sir.",
-        "Lights are offline as requested, sir.",
-    ],
-    "Dim All Lights": [
-        "Lighting dimmed precisely to your specifications, sir.",
-        "I've adjusted the lights for a subtle ambiance, sir.",
-        "Mood lighting protocol successfully engaged, sir.",
-        "I've set all lighting to a comfortable level, sir.",
-        "The illumination has been reduced to optimal comfort, sir.",
-        "Ambient lighting now in effect, sir.",
-        "Lights dimmed to create the desired atmosphere, sir.",
-        "Soft lighting activated throughout the manor, sir.",
-        "Lighting intensity reduced for relaxation, sir.",
-        "Dimmed lighting mode is now active, sir.",
-    ],
-    "Brighten All Lights": [
-        "Illumination levels maximized throughout the manor, sir.",
-        "All lights brightened to their fullest intensity, sir.",
-        "Lighting raised to maximum brightness, sir.",
-        "I've restored lights to full luminosity, sir.",
-        "Bright lighting protocol completed successfully, sir.",
-        "The house is now exceptionally well-lit, sir.",
-        "Full brightness achieved across all rooms, sir.",
-        "Illumination adjusted to maximum clarity, sir.",
-        "Lighting intensity set to highest available levels, sir.",
-        "I've engaged maximum illumination mode, sir.",
-    ],
-    "Flash All Lights": [
-        "Flash sequence completed successfully, sir.",
-        "Lights have flashed precisely as you requested, sir.",
-        "Strobe lighting effect executed successfully, sir.",
-        "Rapid flash protocol concluded, sir.",
-        "All lighting briefly set to flash mode, sir.",
-        "Attention-grabbing flash sequence now complete, sir.",
-        "The lights have executed the flash routine, sir.",
-        "Lighting has briefly cycled through strobe mode, sir.",
-        "Flash operation has been performed without issue, sir.",
-        "Rapid illumination pulses have concluded, sir.",
-    ],
-    "Light Color Control": [
-        "All lights have been set to {color}, sir.",
-        "Lighting adjusted precisely to a {color} hue, sir.",
-        "The manor now features {color} illumination, sir.",
-        "I've completed your requested color adjustment to {color}, sir.",
-        "All ambient lights display {color}, as desired, sir.",
-        "Lighting systems are now emitting a {color} glow, sir.",
-        "The color of illumination has been changed to {color}, sir.",
-        "Lights throughout the residence are now {color}, sir.",
-        "Lighting color protocol successfully activated: {color}, sir.",
-        "I've switched lighting color to your requested {color}, sir.",
-    ],
-    "Get Today's Events": [
-        "I've assembled today's schedule for your review, sir.",
-        "Your daily agenda has been successfully retrieved, sir.",
-        "Today's appointments and events are ready, sir.",
-        "I've compiled the day's planned activities, sir.",
-        "Here's today's itinerary, fully updated, sir.",
-        "Schedule for today has been organized as requested, sir.",
-        "I've prepared today's event summary, sir.",
-        "Your calendar events for the day have been accessed, sir.",
-        "Today's engagements have been arranged and ready, sir.",
-        "All events and meetings for today are now available, sir.",
-    ],
-}
 
 
 class ExecutionResult(str, Enum):
@@ -103,3 +16,4 @@ class ExecutionResult(str, Enum):
     SUCCESS = "success"
     PARTIAL = "partial"
     FAILURE = "failure"
+

--- a/jarvis/protocols/builder.py
+++ b/jarvis/protocols/builder.py
@@ -5,7 +5,7 @@ import json
 import uuid
 from pathlib import Path
 
-from . import Protocol, ProtocolStep
+from . import Protocol, ProtocolStep, ProtocolResponse, ResponseMode
 from .registry import ProtocolRegistry
 
 
@@ -27,11 +27,26 @@ def create_interactively(registry: ProtocolRegistry) -> Protocol:
             parameters = {}
         steps.append(ProtocolStep(intent=intent, parameters=parameters))
 
+    resp_mode = input("Response mode (static/ai, blank for none): ").strip().lower()
+    response = None
+    if resp_mode == "static":
+        phrases_str = input("Response phrases as JSON list: ").strip()
+        try:
+            phrases = json.loads(phrases_str) if phrases_str else []
+        except json.JSONDecodeError:
+            print("Invalid JSON, using empty list")
+            phrases = []
+        response = ProtocolResponse(mode=ResponseMode.STATIC, phrases=phrases)
+    elif resp_mode == "ai":
+        prompt = input("AI response prompt: ").strip()
+        response = ProtocolResponse(mode=ResponseMode.AI, prompt=prompt)
+
     proto = Protocol(
         id=str(uuid.uuid4()),
         name=name,
         description=description,
         steps=steps,
+        response=response,
     )
     registry.register(proto)
     return proto

--- a/jarvis/protocols/defaults/definitions/get_todays_schedule.json
+++ b/jarvis/protocols/defaults/definitions/get_todays_schedule.json
@@ -33,5 +33,11 @@
       "function": "get_today_events",
       "parameters": {}
     }
-  ]
+  ],
+  "responses": {
+    "mode": "static",
+    "phrases": [
+      "Here is today's schedule, sir."
+    ]
+  }
 }

--- a/jarvis/protocols/defaults/definitions/lights_bright_all.json
+++ b/jarvis/protocols/defaults/definitions/lights_bright_all.json
@@ -62,5 +62,11 @@
         "brightness": 254
       }
     }
-  ]
+  ],
+  "responses": {
+    "mode": "static",
+    "phrases": [
+      "Lights at full brightness, sir."
+    ]
+  }
 }

--- a/jarvis/protocols/defaults/definitions/lights_color.json
+++ b/jarvis/protocols/defaults/definitions/lights_color.json
@@ -5,7 +5,17 @@
     {
       "name": "color",
       "type": "choice",
-      "choices": ["red", "blue", "green", "yellow", "white", "purple", "orange", "pink", "read"],
+      "choices": [
+        "red",
+        "blue",
+        "green",
+        "yellow",
+        "white",
+        "purple",
+        "orange",
+        "pink",
+        "read"
+      ],
       "required": true,
       "description": "Color to set the lights"
     }
@@ -58,5 +68,11 @@
         "color_name": "$color"
       }
     }
-  ]
+  ],
+  "responses": {
+    "mode": "static",
+    "phrases": [
+      "Lights set to {color}, sir."
+    ]
+  }
 }

--- a/jarvis/protocols/defaults/definitions/lights_dim_all.json
+++ b/jarvis/protocols/defaults/definitions/lights_dim_all.json
@@ -58,5 +58,11 @@
         "brightness": 64
       }
     }
-  ]
+  ],
+  "responses": {
+    "mode": "static",
+    "phrases": [
+      "Lights dimmed, sir."
+    ]
+  }
 }

--- a/jarvis/protocols/defaults/definitions/lights_flash_all.json
+++ b/jarvis/protocols/defaults/definitions/lights_flash_all.json
@@ -56,5 +56,11 @@
       "function": "flash_all_lights",
       "parameters": {}
     }
-  ]
+  ],
+  "responses": {
+    "mode": "static",
+    "phrases": [
+      "Lights flashed, sir."
+    ]
+  }
 }

--- a/jarvis/protocols/defaults/definitions/lights_off.json
+++ b/jarvis/protocols/defaults/definitions/lights_off.json
@@ -108,5 +108,11 @@
       "function": "turn_off_all_lights",
       "parameters": {}
     }
-  ]
+  ],
+  "responses": {
+    "mode": "static",
+    "phrases": [
+      "All lights powered down, sir."
+    ]
+  }
 }

--- a/jarvis/protocols/defaults/definitions/lights_on.json
+++ b/jarvis/protocols/defaults/definitions/lights_on.json
@@ -90,5 +90,12 @@
       "function": "turn_on_all_lights",
       "parameters": {}
     }
-  ]
+  ],
+  "responses": {
+    "mode": "static",
+    "phrases": [
+      "All lights activated, sir.",
+      "Lighting engaged."
+    ]
+  }
 }

--- a/jarvis/protocols/defaults/definitions/local_weather.json
+++ b/jarvis/protocols/defaults/definitions/local_weather.json
@@ -14,7 +14,15 @@
     {
       "agent": "WeatherAgent",
       "function": "get_current_weather",
-      "parameters": {"location": "Chicago"}
+      "parameters": {
+        "location": "Chicago"
+      }
     }
-  ]
+  ],
+  "responses": {
+    "mode": "static",
+    "phrases": [
+      "Here is the current weather."
+    ]
+  }
 }

--- a/jarvis/protocols/defaults/definitions/weather_forecast.json
+++ b/jarvis/protocols/defaults/definitions/weather_forecast.json
@@ -2,7 +2,12 @@
   "name": "Weather Forecast",
   "description": "Get a short term weather forecast for a location",
   "argument_definitions": [
-    {"name": "location", "type": "text", "required": true, "description": "City or location"}
+    {
+      "name": "location",
+      "type": "text",
+      "required": true,
+      "description": "City or location"
+    }
   ],
   "trigger_phrases": [
     "weather forecast",
@@ -17,7 +22,15 @@
       "agent": "WeatherAgent",
       "function": "get_forecast",
       "parameters": {},
-      "parameter_mappings": {"location": "$location"}
+      "parameter_mappings": {
+        "location": "$location"
+      }
     }
-  ]
+  ],
+  "responses": {
+    "mode": "static",
+    "phrases": [
+      "Forecast retrieved, sir."
+    ]
+  }
 }

--- a/jarvis/protocols/models/__init__.py
+++ b/jarvis/protocols/models/__init__.py
@@ -1,5 +1,13 @@
 from .protocol_step import ProtocolStep
 from .protocol import Protocol
 from .argument_definition import ArgumentDefinition, ArgumentType
+from .protocol_response import ProtocolResponse, ResponseMode
 
-__all__ = ["ProtocolStep", "Protocol", "ArgumentDefinition", "ArgumentType"]
+__all__ = [
+    "ProtocolStep",
+    "Protocol",
+    "ArgumentDefinition",
+    "ArgumentType",
+    "ProtocolResponse",
+    "ResponseMode",
+]

--- a/jarvis/protocols/models/protocol.py
+++ b/jarvis/protocols/models/protocol.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List
 
 from .protocol_step import ProtocolStep
 from .argument_definition import ArgumentDefinition
+from .protocol_response import ProtocolResponse
 
 
 @dataclass
@@ -21,6 +22,7 @@ class Protocol:
     trigger_phrases: List[str] = field(default_factory=list)  # For voice activation
     steps: List[ProtocolStep] = field(default_factory=list)
     argument_definitions: List[ArgumentDefinition] = field(default_factory=list)  # NEW
+    response: ProtocolResponse | None = None
 
     @classmethod
     def from_dict(
@@ -34,6 +36,9 @@ class Protocol:
         arg_defs_data = data.get("argument_definitions", [])
         arg_defs = [ArgumentDefinition.from_dict(ad) for ad in arg_defs_data]
 
+        resp_data = data.get("responses") or data.get("response")
+        response = ProtocolResponse.from_dict(resp_data) if resp_data else None
+
         pid = protocol_id or data.get("id") or str(uuid.uuid4())
         return cls(
             id=pid,
@@ -43,6 +48,7 @@ class Protocol:
             trigger_phrases=data.get("trigger_phrases", [data["name"]]),
             steps=steps,
             argument_definitions=arg_defs,  # NEW
+            response=response,
         )
 
     @classmethod
@@ -61,4 +67,5 @@ class Protocol:
             "trigger_phrases": self.trigger_phrases,
             "steps": [step.__dict__ for step in self.steps],
             "argument_definitions": [ad.to_dict() for ad in self.argument_definitions],
+            "responses": self.response.to_dict() if self.response else None,
         }

--- a/jarvis/protocols/models/protocol_response.py
+++ b/jarvis/protocols/models/protocol_response.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List
+
+class ResponseMode(Enum):
+    """How a protocol should generate its response."""
+
+    STATIC = "static"
+    AI = "ai"
+
+
+@dataclass
+class ProtocolResponse:
+    """Defines how to produce a reply after protocol execution."""
+
+    mode: ResponseMode
+    phrases: List[str] = field(default_factory=list)
+    prompt: str = ""
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ProtocolResponse":
+        return cls(
+            mode=ResponseMode(data["mode"]),
+            phrases=data.get("phrases", []),
+            prompt=data.get("prompt", ""),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        result = {"mode": self.mode.value}
+        if self.phrases:
+            result["phrases"] = self.phrases
+        if self.prompt:
+            result["prompt"] = self.prompt
+        return result
+

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -1,0 +1,59 @@
+import asyncio
+import pytest
+
+from jarvis.main_jarvis import JarvisSystem
+from jarvis.config import JarvisConfig
+from jarvis.protocols import Protocol, ProtocolStep, ProtocolResponse, ResponseMode
+
+
+class DummyAIClient:
+    def __init__(self):
+        self.messages = None
+
+    async def strong_chat(self, messages, tools=None):
+        self.messages = messages
+        return type("Msg", (), {"content": "AI reply"}), None
+
+    async def weak_chat(self, messages, tools=None):
+        return await self.strong_chat(messages, tools)
+
+
+class DummyChatAgent:
+    def __init__(self):
+        self.ai_client = DummyAIClient()
+
+
+@pytest.mark.asyncio
+async def test_static_response():
+    jarvis = JarvisSystem(JarvisConfig())
+    jarvis.chat_agent = DummyChatAgent()
+
+    proto = Protocol(
+        id="1",
+        name="lights_on",
+        description="",
+        steps=[ProtocolStep(agent="a", function="f")],
+        response=ProtocolResponse(mode=ResponseMode.STATIC, phrases=["Lights on {room}"]),
+    )
+    resp = await jarvis._format_protocol_response(proto, {"step_0_f": {}}, {"room": "kitchen"})
+    assert resp == "Lights on kitchen"
+
+
+@pytest.mark.asyncio
+async def test_ai_response():
+    jarvis = JarvisSystem(JarvisConfig())
+    dummy = DummyChatAgent()
+    jarvis.chat_agent = dummy
+
+    proto = Protocol(
+        id="2",
+        name="ai_proto",
+        description="",
+        steps=[ProtocolStep(agent="a", function="f")],
+        response=ProtocolResponse(mode=ResponseMode.AI, prompt="Say hi to {name}"),
+    )
+
+    resp = await jarvis._format_protocol_response(proto, {}, {"name": "Tony"})
+    assert dummy.ai_client.messages[0]["content"] == "Say hi to Tony"
+    assert resp == "AI reply"
+


### PR DESCRIPTION
## Summary
- allow protocols to define response metadata via new dataclasses
- support static or AI-generated replies in JarvisSystem
- persist response JSON in the registry
- update default protocol definitions with sample responses
- provide tests covering both response modes

## Testing
- `pip install -q -r requirements.txt --use-deprecated=legacy-resolver` *(fails: pydantic-core build error)*
- `pytest -q` *(fails: ImportError from pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68785ea89e5c832aaa4506dfcca88811