### PR TITLE
Update weather and calendar protocol responses

### DIFF
--- a/jarvis/protocols/__init__.py
+++ b/jarvis/protocols/__init__.py
@@ -1,6 +1,13 @@
 """Protocol system package"""
 
-from .models import Protocol, ProtocolStep, ArgumentDefinition, ArgumentType
+from .models import (
+    Protocol,
+    ProtocolStep,
+    ArgumentDefinition,
+    ArgumentType,
+    ProtocolResponse,
+    ResponseMode,
+)
 from .loggers import (
     ProtocolUsageLogger,
     ExecutionMetadata,
@@ -14,6 +21,8 @@ __all__ = [
     "ProtocolStep",
     "ArgumentDefinition",
     "ArgumentType",
+    "ProtocolResponse",
+    "ResponseMode",
     "ProtocolUsageLogger",
     "ExecutionMetadata",
     "ProtocolLogEntry",

--- a/jarvis/protocols/defaults/definitions/get_todays_schedule.json
+++ b/jarvis/protocols/defaults/definitions/get_todays_schedule.json
@@ -35,9 +35,7 @@
     }
   ],
   "responses": {
-    "mode": "static",
-    "phrases": [
-      "Here is today's schedule, sir."
-    ]
+    "mode": "ai",
+    "prompt": "Let the user know in a single sentence that today's calendar events were retrieved."
   }
 }

--- a/jarvis/protocols/defaults/definitions/local_weather.json
+++ b/jarvis/protocols/defaults/definitions/local_weather.json
@@ -20,9 +20,7 @@
     }
   ],
   "responses": {
-    "mode": "static",
-    "phrases": [
-      "Here is the current weather."
-    ]
+    "mode": "ai",
+    "prompt": "Briefly tell the user that the current weather for Chicago was retrieved."
   }
 }

--- a/jarvis/protocols/defaults/definitions/weather_forecast.json
+++ b/jarvis/protocols/defaults/definitions/weather_forecast.json
@@ -28,9 +28,7 @@
     }
   ],
   "responses": {
-    "mode": "static",
-    "phrases": [
-      "Forecast retrieved, sir."
-    ]
+    "mode": "ai",
+    "prompt": "Inform the user in one sentence that the weather forecast for {location} was retrieved."
   }
 }


### PR DESCRIPTION
## Summary
- export `ProtocolResponse` and `ResponseMode`
- convert calendar and weather default protocols to use AI mode responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878640f3b9c832aac6be3da53e3069a