### PR TITLE
Add night mode capability tracking

### DIFF
--- a/jarvis/night_agents/__init__.py
+++ b/jarvis/night_agents/__init__.py
@@ -1,0 +1,5 @@
+from .base import NightAgent
+from .trigger_phrase_suggester import TriggerPhraseSuggesterAgent
+from .controller_agent import NightModeControllerAgent
+
+__all__ = ["NightAgent", "TriggerPhraseSuggesterAgent", "NightModeControllerAgent"]

--- a/jarvis/night_agents/base.py
+++ b/jarvis/night_agents/base.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Coroutine, Optional
+
+from ..agents.base import NetworkAgent
+from ..logger import JarvisLogger
+
+
+class NightAgent(NetworkAgent):
+    """Base class for agents that run background tasks during night mode."""
+
+    def __init__(self, name: str, logger: Optional[JarvisLogger] = None) -> None:
+        super().__init__(name, logger)
+        self._background_tasks: list[asyncio.Task] = []
+
+    async def start_background_tasks(self) -> None:
+        """Start background work. Override in subclass."""
+        return None
+
+    async def stop_background_tasks(self) -> None:
+        """Stop all running background tasks."""
+        for task in list(self._background_tasks):
+            task.cancel()
+            try:
+                await task
+            except Exception:
+                pass
+        self._background_tasks.clear()
+
+    def _create_background_task(self, coro: Coroutine[Any, Any, Any]) -> None:
+        task = asyncio.create_task(coro)
+        self._background_tasks.append(task)
+
+    def activate_capabilities(self) -> None:
+        """Expose this agent's capabilities on the network."""
+        if self.network:
+            self.network.add_agent_capabilities(self)
+
+    def deactivate_capabilities(self) -> None:
+        """Hide this agent's capabilities from the network."""
+        if self.network:
+            self.network.remove_agent_capabilities(self)

--- a/jarvis/night_agents/controller_agent.py
+++ b/jarvis/night_agents/controller_agent.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Optional, Set
+
+from ..agents.base import NetworkAgent
+from ..agents.message import Message
+from ..logger import JarvisLogger
+
+if "typing" == "typing":
+    from ..main_jarvis import JarvisSystem
+
+
+class NightModeControllerAgent(NetworkAgent):
+    """Agent that toggles Jarvis night mode."""
+
+    def __init__(self, system: "JarvisSystem", logger: Optional[JarvisLogger] = None) -> None:
+        super().__init__("NightModeControllerAgent", logger)
+        self.system = system
+
+    @property
+    def description(self) -> str:
+        return "Controls entry and exit from night mode"
+
+    @property
+    def capabilities(self) -> Set[str]:
+        return {"start_night_mode", "stop_night_mode"}
+
+    async def _handle_capability_request(self, message: Message) -> None:
+        capability = message.content.get("capability")
+        if capability == "start_night_mode":
+            await self.system.enter_night_mode()
+            await self.send_capability_response(
+                message.from_agent,
+                {"status": "night_mode_enabled"},
+                message.request_id,
+                message.id,
+            )
+        elif capability == "stop_night_mode":
+            await self.system.exit_night_mode()
+            await self.send_capability_response(
+                message.from_agent,
+                {"status": "night_mode_disabled"},
+                message.request_id,
+                message.id,
+            )
+
+    async def _handle_capability_response(self, message: Message) -> None:
+        # Controller does not expect capability responses
+        return None

--- a/jarvis/night_agents/trigger_phrase_suggester.py
+++ b/jarvis/night_agents/trigger_phrase_suggester.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from typing import List, Optional, Set
+
+from .base import NightAgent
+from ..loggers.jarvis_logger import JarvisLogger
+from ..constants import LOG_DB_PATH
+from ..agents.message import Message
+
+
+class TriggerPhraseSuggesterAgent(NightAgent):
+    """Suggest new protocol trigger phrases from logs."""
+
+    def __init__(self, logger: Optional[JarvisLogger] = None, db_path: str = LOG_DB_PATH) -> None:
+        super().__init__("TriggerPhraseSuggester", logger)
+        self.db_path = db_path
+
+    @property
+    def description(self) -> str:
+        return "Analyzes logs to suggest new protocol trigger phrases"
+
+    @property
+    def capabilities(self) -> Set[str]:
+        return {"suggest_trigger_phrases"}
+
+    async def _handle_capability_request(self, message: Message) -> None:
+        if message.content.get("capability") != "suggest_trigger_phrases":
+            return
+        phrases = await self._suggest_trigger_phrases()
+        await self.send_capability_response(
+            to_agent=message.from_agent,
+            result={"phrases": phrases},
+            request_id=message.request_id,
+            original_message_id=message.id,
+        )
+
+    async def _handle_capability_response(self, message: Message) -> None:
+        return None
+
+    async def start_background_tasks(self) -> None:
+        self._create_background_task(self._periodic_scan())
+
+    async def _periodic_scan(self) -> None:
+        while True:
+            await self._suggest_trigger_phrases()
+            await asyncio.sleep(3600)
+
+    async def _suggest_trigger_phrases(self) -> List[str]:
+        try:
+            conn = sqlite3.connect(self.db_path)
+            rows = conn.execute(
+                "SELECT details FROM logs WHERE action LIKE 'Trigger matched%' ORDER BY timestamp DESC LIMIT 100"
+            ).fetchall()
+            conn.close()
+            phrases = []
+            for (details,) in rows:
+                if not details:
+                    continue
+                if "Command:" in details:
+                    start = details.find("Command: '") + len("Command: '")
+                    end = details.find("'", start)
+                    if start > -1 and end > start:
+                        phrase = details[start:end]
+                        phrases.append(phrase)
+            # deduplicate while preserving order
+            seen = set()
+            unique = []
+            for p in phrases:
+                if p not in seen:
+                    seen.add(p)
+                    unique.append(p)
+            return unique
+        except Exception as exc:
+            if self.logger:
+                self.logger.log("ERROR", "Trigger phrase suggestion failed", str(exc))
+            return []

--- a/jarvis/protocols/defaults/definitions/goodnight.json
+++ b/jarvis/protocols/defaults/definitions/goodnight.json
@@ -1,0 +1,22 @@
+{
+  "name": "goodnight",
+  "description": "Enter night mode for maintenance tasks",
+  "trigger_phrases": [
+    "goodnight",
+    "enter night mode",
+    "night mode"
+  ],
+  "steps": [
+    {
+      "agent": "NightModeControllerAgent",
+      "function": "start_night_mode",
+      "parameters": {}
+    }
+  ],
+  "responses": {
+    "mode": "static",
+    "phrases": [
+      "Entering night mode, sir."
+    ]
+  }
+}

--- a/jarvis/protocols/defaults/definitions/wake_up.json
+++ b/jarvis/protocols/defaults/definitions/wake_up.json
@@ -1,0 +1,22 @@
+{
+  "name": "wake_up",
+  "description": "Exit night mode and resume normal operation",
+  "trigger_phrases": [
+    "wake up",
+    "exit night mode",
+    "good morning jarvis"
+  ],
+  "steps": [
+    {
+      "agent": "NightModeControllerAgent",
+      "function": "stop_night_mode",
+      "parameters": {}
+    }
+  ],
+  "responses": {
+    "mode": "static",
+    "phrases": [
+      "Back online, sir."
+    ]
+  }
+}

--- a/tests/test_agent_network.py
+++ b/tests/test_agent_network.py
@@ -31,3 +31,55 @@ async def test_message_routing():
 
     assert msg.content == {"foo": "bar"}
     assert msg.from_agent == "sender"
+
+
+class CapAgent(NetworkAgent):
+    def __init__(self, name):
+        super().__init__(name)
+
+    @property
+    def capabilities(self):
+        return {"foo"}
+
+    async def _handle_capability_request(self, message):
+        pass
+
+
+def test_add_remove_capabilities():
+    network = AgentNetwork()
+    agent = CapAgent("cap")
+    network.register_agent(agent, include_capabilities=False)
+    assert "foo" not in network.capability_registry
+
+    network.add_agent_capabilities(agent)
+    assert network.capability_registry.get("foo") == ["cap"]
+
+    network.remove_agent_capabilities(agent)
+    assert "foo" not in network.capability_registry
+
+
+class NightCapAgent(NetworkAgent):
+    def __init__(self, name):
+        super().__init__(name)
+
+    @property
+    def capabilities(self):
+        return {"bar"}
+
+    async def _handle_capability_request(self, message):
+        pass
+
+
+def test_register_night_agent():
+    network = AgentNetwork()
+    agent = NightCapAgent("night")
+    network.register_night_agent(agent)
+    assert agent.name in network.night_agents
+    assert "bar" not in network.capability_registry
+    assert network.night_capability_registry.get("bar") == ["night"]
+
+    network.add_agent_capabilities(agent)
+    assert network.capability_registry.get("bar") == ["night"]
+
+    network.remove_agent_capabilities(agent)
+    assert "bar" not in network.capability_registry


### PR DESCRIPTION
## Summary
- track night agents and their capabilities inside `AgentNetwork`
- provide a helper to register night agents
- let `JarvisSystem` register night agents via helper
- expose methods for night agents to activate/deactivate capabilities
- test night agent registration and capability activation

## Testing
- `pytest tests/test_agent_network.py -q`
- `pytest -q` *(fails: 4 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68786f0d61d4832ab24669a25716c19b