### PR TITLE
Add query_memory capability

### DIFF
--- a/jarvis/agents/base.py
+++ b/jarvis/agents/base.py
@@ -204,6 +204,23 @@ class NetworkAgent:
             return result
         return []
 
+    async def query_memory(
+        self,
+        memory_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        limit: Optional[int] = None,
+    ) -> list[Dict[str, Any]]:
+        """Query the shared vector memory via MemoryAgent."""
+        if not self.network:
+            return []
+        req_id = await self.request_capability(
+            "query_memory", {"memory_id": memory_id, "metadata": metadata, "limit": limit}
+        )
+        result = await self.network.wait_for_response(req_id)
+        if isinstance(result, list):
+            return result
+        return []
+
     def update_profile(self, **fields: Any) -> None:
         """Update the agent's profile in-place."""
         if not self.profile:

--- a/jarvis/agents/memory_agent/__init__.py
+++ b/jarvis/agents/memory_agent/__init__.py
@@ -28,7 +28,7 @@ class MemoryAgent(NetworkAgent):
 
     @property
     def capabilities(self) -> Set[str]:
-        return {"store_memory", "search_memory"}
+        return {"store_memory", "search_memory", "query_memory"}
 
     async def _handle_capability_request(self, message: Message) -> None:
         capability = message.content.get("capability")
@@ -69,6 +69,19 @@ class MemoryAgent(NetworkAgent):
                 await self.send_capability_response(
                     message.from_agent,
                     {"response": summary, "actions": []},
+                    message.request_id,
+                    message.id,
+                )
+            except Exception as exc:
+                await self.send_error(message.from_agent, str(exc), message.request_id)
+        elif capability == "query_memory":
+            mem_id = data.get("memory_id")
+            metadata = data.get("metadata")
+            try:
+                results = await self.vector_memory.query_memory(mem_id, metadata)
+                await self.send_capability_response(
+                    message.from_agent,
+                    results,
                     message.request_id,
                     message.id,
                 )

--- a/jarvis/services/vector_memory.py
+++ b/jarvis/services/vector_memory.py
@@ -98,3 +98,29 @@ class VectorMemoryService:
         docs = result.get("documents", [[]])[0]
         metas = result.get("metadatas", [[]])[0]
         return [{"text": doc, "metadata": meta} for doc, meta in zip(docs, metas)]
+
+    async def query_memory(
+        self,
+        memory_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        limit: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """Retrieve memories by id or metadata filters."""
+        kwargs: Dict[str, Any] = {}
+        if memory_id:
+            kwargs["ids"] = [memory_id]
+        if metadata:
+            kwargs["where"] = metadata
+        if limit is not None:
+            kwargs["limit"] = limit
+
+        result = await asyncio.to_thread(self.collection.get, **kwargs)
+
+        docs = result.get("documents", [])
+        metas = result.get("metadatas", [])
+        ids = result.get("ids", [])
+
+        return [
+            {"id": i, "text": doc, "metadata": meta}
+            for i, doc, meta in zip(ids, docs, metas)
+        ]


### PR DESCRIPTION
## Summary
- extend MemoryAgent with query_memory capability
- implement query_memory in VectorMemoryService
- expose query_memory method on NetworkAgent
- verify with new tests for MemoryAgent and orchestrator

## Testing
- `pytest tests/test_memory_agent.py::test_memory_agent_routing -q`
- `pytest tests/test_orchestrator.py::test_orchestrator_query_memory_plan -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879bcb2c328832abb2a16dc2b447363