### PR TITLE
Shift agents to prompt-based orchestration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,10 @@ Logs are stored in `jarvis_logs.db`. Use the log viewer:
 python -m jarvis.log_viewer
 ```
 
+## Orchestrator prompts
+The orchestrator now calls `weak_chat` to craft a short prompt for each capability step. Agents expect this
+`prompt` string in incoming `capability_request` messages and no longer receive a `command` field.
+
 ## Tests
 Automated tests live under the `tests/` directory. Install the dependencies from
 `requirements.txt` (or run `poetry install`) and execute:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ python server.py
 ```
 
 The `/jarvis` endpoint accepts a JSON body with a `command` field describing the calendar request.
+The orchestrator now uses a quick LLM call to translate each step into a precise prompt for the relevant agent. Capability requests therefore include a `prompt` field that agents interpret themselves.
 The `/protocols` endpoint returns all registered protocols and their details as JSON.
 You can also run a protocol directly via `/protocols/run` by sending either a protocol definition or the name of a registered protocol.
 

--- a/jarvis/agents/base.py
+++ b/jarvis/agents/base.py
@@ -183,7 +183,7 @@ class NetworkAgent:
         if not self.network:
             return None
         req_id = await self.request_capability(
-            "store_memory", {"command": text, "metadata": metadata}
+            "store_memory", {"prompt": text, "metadata": metadata}
         )
         result = await self.network.wait_for_response(req_id)
         if isinstance(result, str):
@@ -197,7 +197,7 @@ class NetworkAgent:
         if not self.network:
             return []
         req_id = await self.request_capability(
-            "search_memory", {"command": query, "top_k": top_k}
+            "search_memory", {"prompt": query, "top_k": top_k}
         )
         result = await self.network.wait_for_response(req_id)
         if isinstance(result, list):

--- a/jarvis/agents/calendar_agent/agent.py
+++ b/jarvis/agents/calendar_agent/agent.py
@@ -104,17 +104,17 @@ class CollaborativeCalendarAgent(NetworkAgent):
         )
 
         try:
-            command = data.get("command")
-            if not isinstance(command, str):
+            prompt = data.get("prompt")
+            if not isinstance(prompt, str):
                 await self.send_error(
-                    message.from_agent, "Invalid command", message.request_id
+                    message.from_agent, "Invalid prompt", message.request_id
                 )
                 return
 
             if self.logger:
-                self.logger.log("INFO", "Processing command", command)
+                self.logger.log("INFO", "Processing prompt", prompt)
 
-            result = await self.command_processor.process_command(command)
+            result = await self.command_processor.process_command(prompt)
 
             if result:
                 await self.send_capability_response(

--- a/jarvis/agents/canvas/__init__.py
+++ b/jarvis/agents/canvas/__init__.py
@@ -493,14 +493,14 @@ class CanvasAgent(NetworkAgent):
         )
 
         try:
-            command = data.get("command")
-            if not isinstance(command, str):
+            prompt = data.get("prompt")
+            if not isinstance(prompt, str):
                 await self.send_error(
-                    message.from_agent, "Invalid command", message.request_id
+                    message.from_agent, "Invalid prompt", message.request_id
                 )
                 return
 
-            result = await self._process_canvas_command(command)
+            result = await self._process_canvas_command(prompt)
             await self.send_capability_response(
                 message.from_agent, result, message.request_id, message.id
             )

--- a/jarvis/agents/chat_agent/__init__.py
+++ b/jarvis/agents/chat_agent/__init__.py
@@ -264,7 +264,7 @@ class ChatAgent(NetworkAgent):
 
         try:
             if capability in self.function_map:
-                user_input = data.get("message", data.get("command", ""))
+                user_input = data.get("message", data.get("prompt", ""))
 
                 # Add context awareness
                 context = await self._analyze_context(user_input)

--- a/jarvis/agents/lights_agent/__init__.py
+++ b/jarvis/agents/lights_agent/__init__.py
@@ -1109,10 +1109,10 @@ class PhillipsHueAgent(NetworkAgent):
 
         self.logger.log("INFO", f"Handling capability: {capability}", str(data))
 
-        cmd = data.get("command")
+        cmd = data.get("prompt")
         if not isinstance(cmd, str):
             await self.send_error(
-                message.from_agent, "Invalid or missing command", message.request_id
+                message.from_agent, "Invalid or missing prompt", message.request_id
             )
             return
         result = await self._process_hue_command(cmd)

--- a/jarvis/agents/memory_agent/__init__.py
+++ b/jarvis/agents/memory_agent/__init__.py
@@ -34,7 +34,7 @@ class MemoryAgent(NetworkAgent):
         data = message.content.get("data", {})
 
         if capability == "store_memory":
-            command = data.get("command")
+            command = data.get("prompt")
             metadata = data.get("metadata")
             if not command:
                 await self.send_error(
@@ -50,7 +50,7 @@ class MemoryAgent(NetworkAgent):
                 await self.send_error(message.from_agent, str(exc), message.request_id)
         elif capability == "search_memory":
             print(data, "DATA IN MEMORY AGENT")
-            command = data.get("command")
+            command = data.get("prompt")
             top_k = data.get("top_k", 3)
             if not command:
                 await self.send_error(

--- a/jarvis/agents/software_engineering_agent/__init__.py
+++ b/jarvis/agents/software_engineering_agent/__init__.py
@@ -172,7 +172,7 @@ class SoftwareEngineeringAgent(NetworkAgent):
 
     async def _handle_capability_request(self, message: Message) -> None:
         """Handle all capability requests by sending to Aider."""
-        command = message.content.get("data", {}).get("command", "")
+        command = message.content.get("data", {}).get("prompt", "")
 
         if not command:
             await self.send_error(

--- a/jarvis/agents/task.py
+++ b/jarvis/agents/task.py
@@ -14,3 +14,4 @@ class Task:
     intent: Optional[str] = None
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     result: Any = None
+    prompt: Optional[str] = None

--- a/jarvis/agents/weather_agent/agent.py
+++ b/jarvis/agents/weather_agent/agent.py
@@ -91,11 +91,11 @@ class WeatherAgent(NetworkAgent):
             self.logger.log("INFO", f"WeatherAgent handling: {capability}")
 
         try:
-            command = data.get("command", data.get("message", ""))
+            command = data.get("prompt", data.get("message", ""))
             if not command:
                 await self.send_error(
                     message.from_agent,
-                    "No weather command provided",
+                    "No weather prompt provided",
                     message.request_id,
                 )
                 return

--- a/jarvis/main_jarvis.py
+++ b/jarvis/main_jarvis.py
@@ -371,7 +371,7 @@ class JarvisSystem:
             # 4) Route to the appropriate agent
             if intent == "perform_capability" and cap:
                 request_id = str(uuid.uuid4())
-                payload = {"command": user_input}
+                payload = {"prompt": user_input}
                 if args:
                     payload.update(args)
                 if cap == "store_memory":
@@ -381,7 +381,7 @@ class JarvisSystem:
                         if args.get("memory_type")
                         else {}
                     )
-                    payload = {"command": cmd, "metadata": meta}
+                    payload = {"prompt": cmd, "metadata": meta}
                 async with tracker.timer(
                     "agent_response", metadata={"agent": target or cap}
                 ):
@@ -449,7 +449,7 @@ class JarvisSystem:
 
             if intent == "chat":
                 define_id = str(uuid.uuid4())
-                payload = {"command": user_input}
+                payload = {"prompt": user_input}
                 async with tracker.timer(
                     "agent_response", metadata={"agent": target or "chat"}
                 ):

--- a/tests/test_calendar_agent.py
+++ b/tests/test_calendar_agent.py
@@ -1,0 +1,34 @@
+import pytest
+import asyncio
+
+from jarvis.agents.calendar_agent import CollaborativeCalendarAgent
+from jarvis.agents.message import Message
+from jarvis.ai_clients.base import BaseAIClient
+from jarvis.services.calendar_service import CalendarService
+
+class DummyAIClient(BaseAIClient):
+    async def strong_chat(self, messages, tools=None):
+        return None, None
+    async def weak_chat(self, messages, tools=None):
+        return None, None
+
+@pytest.mark.asyncio
+async def test_calendar_agent_prompt(monkeypatch):
+    service = CalendarService()
+    agent = CollaborativeCalendarAgent(ai_client=DummyAIClient(), calendar_service=service)
+    async def fake_process(cmd):
+        return {"echo": cmd}
+    monkeypatch.setattr(agent.command_processor, "process_command", fake_process)
+    captured = {}
+    async def fake_send(to, result, request_id, msg_id):
+        captured["result"] = result
+    monkeypatch.setattr(agent, "send_capability_response", fake_send)
+    message = Message(
+        from_agent="tester",
+        to_agent="CalendarAgent",
+        message_type="capability_request",
+        content={"capability": next(iter(agent.capabilities)), "data": {"prompt": "hi"}},
+        request_id="1",
+    )
+    await agent._handle_capability_request(message)
+    assert captured["result"]["echo"] == "hi"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -57,6 +57,7 @@ async def test_orchestrator_sequence():
     ai = DummyAIClient(
         [
             '{"intent":"test","capabilities_needed":["dummy_cap"],"dependencies":{}}',
+            "do it",
             "All done",
         ]
     )
@@ -71,7 +72,8 @@ async def test_orchestrator_sequence():
     await network.stop()
 
     assert result["success"] is True
-    assert not provider.received.empty()
+    msg = provider.received.get_nowait()
+    assert msg.content["data"]["prompt"] == "do it"
 
 
 @pytest.mark.asyncio
@@ -79,6 +81,7 @@ async def test_orchestrator_query_memory_plan():
     ai = DummyAIClient(
         [
             '{"intent":"test","capabilities_needed":["query_memory"],"dependencies":{}}',
+            "fetch it",
             "All done",
         ]
     )
@@ -93,4 +96,5 @@ async def test_orchestrator_query_memory_plan():
     await network.stop()
 
     assert result["success"] is True
-    assert not provider.received.empty()
+    msg = provider.received.get_nowait()
+    assert msg.content["data"]["prompt"] == "fetch it"

--- a/tests/test_weather_agent.py
+++ b/tests/test_weather_agent.py
@@ -54,7 +54,7 @@ async def test_handle_request(monkeypatch):
         from_agent="tester",
         to_agent="WeatherAgent",
         message_type="capability_request",
-        content={"capability": "weather_command", "data": {"command": "Paris"}},
+        content={"capability": "weather_command", "data": {"prompt": "Paris"}},
         request_id="1"
     )
     await agent._handle_capability_request(message)


### PR DESCRIPTION
## Summary
- orchestrator drafts prompts for each task via `_draft_prompt_via_llm`
- agents read `prompt` field instead of `command`
- log the generated prompt and resulting output
- add regression tests for orchestrator and calendar agent
- document the new interaction pattern

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879c3133380832aa353d75432da499c