### PR TITLE
Add agent permission enforcement

### DIFF
--- a/jarvis/main_jarvis.py
+++ b/jarvis/main_jarvis.py
@@ -334,6 +334,7 @@ class JarvisSystem:
                             match_result,
                             trigger_phrase=user_input,
                             metadata=metadata,
+                            allowed_agents=allowed_agents,
                         )
 
                     response = await self._format_protocol_response(

--- a/jarvis/protocols/defaults/loader.py
+++ b/jarvis/protocols/defaults/loader.py
@@ -82,7 +82,7 @@ async def execute_protocol_file(
     executor = ProtocolExecutor(jarvis.network, jarvis.logger)
     proto = Protocol.from_file(file_path)
     logger.log("INFO", f"Executing protocol: {proto.name}")
-    results = await executor.execute(proto)
+    results = await executor.execute(proto, allowed_agents=None)
     logger.log("INFO", "Results", results)
     await jarvis.shutdown()
 
@@ -238,7 +238,9 @@ def launch_protocol_management_cli() -> None:
                 async def run_protocol():
                     jarvis = await create_collaborative_jarvis()
                     executor = ProtocolExecutor(jarvis.network, jarvis.logger)
-                    results = await executor.execute(proto, context=arguments)
+                    results = await executor.execute(
+                        proto, context=arguments, allowed_agents=None
+                    )
                     await jarvis.shutdown()
                     return results
 

--- a/server/routers/protocols.py
+++ b/server/routers/protocols.py
@@ -5,7 +5,7 @@ from jarvis import JarvisSystem
 from jarvis.protocols import Protocol
 
 from ..models import ProtocolRunRequest
-from ..dependencies import get_jarvis
+from ..dependencies import get_jarvis, get_user_allowed_agents
 
 
 router = APIRouter()
@@ -26,6 +26,7 @@ async def list_protocols(
 async def run_protocol(
     req: ProtocolRunRequest,
     jarvis_system: JarvisSystem = Depends(get_jarvis),
+    allowed: set[str] = Depends(get_user_allowed_agents),
 ):
     """Run a protocol provided directly or by name."""
     if req.protocol is None and req.protocol_name is None:
@@ -41,5 +42,7 @@ async def run_protocol(
         if proto is None:
             raise HTTPException(404, detail="Protocol not found")
 
-    results = await jarvis_system.protocol_executor.run_protocol(proto, req.arguments)
+    results = await jarvis_system.protocol_executor.run_protocol(
+        proto, req.arguments, allowed_agents=allowed
+    )
     return {"protocol": proto.name, "results": results}

--- a/tests/test_api_run_protocol.py
+++ b/tests/test_api_run_protocol.py
@@ -6,6 +6,7 @@ import pytest
 from httpx import ASGITransport
 
 import server
+from server.dependencies import get_user_allowed_agents
 from jarvis.agents.agent_network import AgentNetwork
 from jarvis.agents.base import NetworkAgent
 from jarvis.logger import JarvisLogger
@@ -41,6 +42,7 @@ async def test_run_protocol_endpoint(tmp_path):
         return jarvis
 
     server.app.dependency_overrides[server.get_jarvis] = override_get_jarvis
+    server.app.dependency_overrides[get_user_allowed_agents] = lambda: {"dummy"}
 
     proto = Protocol(
         id="1",
@@ -64,3 +66,5 @@ async def test_run_protocol_endpoint(tmp_path):
         assert resp.status_code == 200
         data = resp.json()
         assert data["results"]["step_0_echo"]["echo"] == {"msg": "hi"}
+
+    server.app.dependency_overrides.clear()

--- a/tests/test_permission_enforcement.py
+++ b/tests/test_permission_enforcement.py
@@ -1,0 +1,112 @@
+import asyncio
+import httpx
+import pytest
+from httpx import ASGITransport
+from types import SimpleNamespace
+
+import server
+from server.dependencies import get_user_allowed_agents
+from jarvis.protocols import Protocol, ProtocolStep
+from jarvis.protocols.executor import ProtocolExecutor
+from jarvis.protocols.voice_trigger import VoiceTriggerMatcher
+from jarvis.agents.agent_network import AgentNetwork
+from jarvis.agents.base import NetworkAgent
+from jarvis.logger import JarvisLogger
+from jarvis.main_jarvis import JarvisSystem, JarvisConfig
+from jarvis.protocols.registry import ProtocolRegistry
+
+
+class DummyAgent(NetworkAgent):
+    def __init__(self, name="dummy"):
+        super().__init__(name)
+        self.intent_map = {"echo": self.echo, "do": self.echo}
+        self.called = 0
+
+    @property
+    def capabilities(self):
+        return {"echo", "do"}
+
+    async def echo(self, **kwargs):
+        self.called += 1
+        return {"echo": True}
+
+
+@pytest.mark.asyncio
+async def test_protocol_run_disallowed_agent(tmp_path):
+    logger = JarvisLogger()
+    network = AgentNetwork(logger)
+    agent = DummyAgent()
+    network.register_agent(agent)
+    executor = ProtocolExecutor(network, logger)
+    registry = ProtocolRegistry(db_path=str(tmp_path / "db.sqlite"), logger=logger)
+    jarvis = SimpleNamespace(protocol_executor=executor, protocol_registry=registry)
+
+    async def override_get_jarvis():
+        return jarvis
+
+    async def override_allowed():
+        return {"other"}
+
+    server.app.dependency_overrides[server.get_jarvis] = override_get_jarvis
+    server.app.dependency_overrides[get_user_allowed_agents] = override_allowed
+
+    proto = Protocol(
+        id="1",
+        name="Echo",
+        description="",
+        steps=[ProtocolStep(agent="dummy", function="echo", parameters={})],
+    )
+
+    server.app.router.on_startup.clear()
+    server.app.router.on_shutdown.clear()
+    transport = ASGITransport(app=server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/protocols/run", json={"protocol": proto.to_dict()})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["results"]["step_0_echo"]["error"] == "agent_disallowed"
+        assert agent.called == 0
+
+    server.app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_voice_trigger_disallowed_agent(tmp_path):
+    logger = JarvisLogger()
+    jarvis = JarvisSystem(JarvisConfig())
+    dummy = DummyAgent()
+    jarvis.network.register_agent(dummy)
+    nlu = DummyAgent("nlu")
+    jarvis.network.register_agent(nlu)
+    jarvis.nlu_agent = nlu
+    jarvis.protocol_executor = ProtocolExecutor(jarvis.network, logger)
+
+    proto = Protocol(
+        id="1",
+        name="Test",
+        description="",
+        trigger_phrases=["do test"],
+        steps=[ProtocolStep(agent="dummy", function="do", parameters={})],
+    )
+    jarvis.voice_matcher = VoiceTriggerMatcher({proto.id: proto})
+
+    async def override_get_jarvis():
+        return jarvis
+
+    async def override_allowed():
+        return {"other"}
+
+    server.app.dependency_overrides[server.get_jarvis] = override_get_jarvis
+    server.app.dependency_overrides[get_user_allowed_agents] = override_allowed
+
+    server.app.router.on_startup.clear()
+    server.app.router.on_shutdown.clear()
+    transport = ASGITransport(app=server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/jarvis/", json={"command": "do test"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert dummy.called == 0
+        assert "agent_disallowed" in data["response"]
+
+    server.app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- enforce agent permissions in ProtocolExecutor
- propagate allowed agent set when protocols run
- restrict `/protocols/run` with authentication
- test that disallowed agents are skipped

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881c411a9c0832a8c2157d28f69975c