### PR TITLE
Add intent timeout handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ python -m asyncio run main.py
 ## JarvisSystem options
 - `response_timeout` – number of seconds the orchestrator waits for
   capability responses when processing a user request. Defaults to 10 seconds.
+- `intent_timeout` – seconds to wait for NLU classification before giving up. Defaults to 5 seconds.
 
 ## Logs
 Logs are stored in `jarvis_logs.db`. Use the log viewer:

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -14,6 +14,7 @@ class JarvisConfig:
     calendar_api_url: str = "http://localhost:8080"
     repo_path: str = "."
     response_timeout: float = 15.0
+    intent_timeout: float = 5.0
     perf_tracking: bool = True
     memory_dir: Optional[str] = None
     # perf_tracking: bool = os.getenv(

--- a/tests/test_intent_timeout.py
+++ b/tests/test_intent_timeout.py
@@ -1,0 +1,35 @@
+import asyncio
+import pytest
+
+from jarvis.main_jarvis import JarvisSystem
+from jarvis.config import JarvisConfig
+from jarvis.agents.base import NetworkAgent
+
+class SilentNLUAgent(NetworkAgent):
+    def __init__(self):
+        super().__init__("nlu")
+
+    @property
+    def capabilities(self):
+        return {"intent_matching"}
+
+    async def _handle_capability_request(self, message):
+        # Do not respond
+        return
+
+    async def _handle_capability_response(self, message):
+        pass
+
+@pytest.mark.asyncio
+async def test_nlu_classification_timeout():
+    config = JarvisConfig(intent_timeout=0.05)
+    jarvis = JarvisSystem(config)
+    silent = SilentNLUAgent()
+    jarvis.nlu_agent = silent
+    jarvis.network.register_agent(silent)
+
+    await jarvis.network.start()
+    result = await jarvis.process_request("hello", "UTC", allowed_agents=None)
+    await jarvis.network.stop()
+
+    assert "too long" in result["response"]


### PR DESCRIPTION
## Summary
- expose `intent_timeout` config option
- default the timeout in `create_collaborative_jarvis`
- apply timeout when waiting for NLU classification
- document the new option
- test NLU timeout behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881c745ac5c832a86be2a3f8840c508