### PR TITLE
Avoid hang on missing capability

### DIFF
--- a/jarvis/main_jarvis.py
+++ b/jarvis/main_jarvis.py
@@ -423,7 +423,19 @@ class JarvisSystem:
                     self.logger.log(
                         "DEBUG", f"Requested '{cap}' from {providers}", payload
                     )
-                    result = await self.network.wait_for_response(request_id)
+                    if not providers:
+                        self.logger.log(
+                            "WARNING",
+                            "No providers found for requested capability",
+                            cap,
+                        )
+                        return {
+                            "response": "No agent is available to handle that request."
+                        }
+
+                    result = await self.network.wait_for_response(
+                        request_id, timeout=self.config.response_timeout
+                    )
                 return {"response": result}
 
             if intent == "orchestrate_tasks":

--- a/tests/test_unavailable_capability.py
+++ b/tests/test_unavailable_capability.py
@@ -1,0 +1,50 @@
+import asyncio
+import pytest
+
+from jarvis.main_jarvis import JarvisSystem
+from jarvis.config import JarvisConfig
+from jarvis.agents.base import NetworkAgent
+
+
+class DummyNLU(NetworkAgent):
+    def __init__(self):
+        super().__init__("nlu")
+
+    @property
+    def capabilities(self):
+        return {"intent_matching"}
+
+    async def _handle_capability_request(self, message):
+        response = {
+            "intent": "perform_capability",
+            "capability": "nonexistent",
+            "target_agent": "",
+            "args": {},
+            "raw": message.content["data"]["input"],
+        }
+        await self.send_capability_response(
+            message.from_agent, response, message.request_id, message.id
+        )
+
+    async def _handle_capability_response(self, message):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_missing_capability_returns_error():
+    jarvis = JarvisSystem(JarvisConfig(intent_timeout=0.1, response_timeout=0.1))
+    nlu = DummyNLU()
+    jarvis.nlu_agent = nlu
+    jarvis.network.register_agent(nlu)
+
+    await jarvis.network.start()
+    try:
+        result = await asyncio.wait_for(
+            jarvis.process_request("test", "UTC", allowed_agents=None),
+            timeout=1.0,
+        )
+    finally:
+        await jarvis.network.stop()
+
+    assert result["response"] == "No agent is available to handle that request."
+


### PR DESCRIPTION
## Summary
- detect when no provider can handle a capability request
- return a user friendly message instead of hanging
- time out capability responses
- test missing capability branch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881caf4b680832a9bd1ef0e3d364e70