### PR TITLE
Add top-level agents API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ The orchestrator now uses a quick LLM call to translate each step into a precise
 The `/protocols` endpoint returns all registered protocols and their details as JSON.
 You can also run a protocol directly via `/protocols/run` by sending either a protocol definition or the name of a registered protocol.
 
+The `/agents` route exposes information about each available agent. `GET /agents`
+returns the full list, `GET /agents/{name}` retrieves details for a single agent
+and `GET /agents/{name}/capabilities` lists its capabilities. These endpoints are
+also accessible under `/jarvis/agents` for compatibility.
+
 ### User agent permissions
 
 Each authenticated user may allow or deny individual agents. Use the following endpoints to manage preferences:

--- a/docs/frontend_implementation.md
+++ b/docs/frontend_implementation.md
@@ -68,19 +68,26 @@ Response is the final structured result returned by the orchestrator. Example:
 ```
 The exact schema depends on the active agents and protocols.
 
-### `GET /jarvis/agents`
-Return a mapping of all available agents.
+### `GET /agents`
+Return a mapping of all registered agents. This information is also available at
+`/jarvis/agents` for backward compatibility.
 Example response:
 ```json
 {
-  "CalendarAgent": "CollaborativeCalendarAgent",
-  "WeatherAgent": "WeatherAgent"
+  "CalendarAgent": {
+    "name": "CalendarAgent",
+    "capabilities": [...]
+  }
 }
 ```
 
-### `GET /jarvis/agents/{name}/capabilities`
+### `GET /agents/{name}`
+Retrieve information about a single agent including its description and
+capability names.
+
+### `GET /agents/{name}/capabilities`
 List capability definitions for the specified agent.
-Response is an array describing each capability and its parameters.
+These routes are mirrored under `/jarvis/agents` as well.
 
 ## Protocol Management
 
@@ -141,7 +148,7 @@ Response:
 
 ## Usage Workflow
 1. **Sign up or log in** to obtain a JWT token.
-2. **Call `/jarvis`** with a natural language command. Optionally query `/jarvis/agents` to inspect available agents first.
+2. **Call `/jarvis`** with a natural language command. Optionally query `/agents` (or `/jarvis/agents`) to inspect available agents first.
 3. **Review the result** and use `/protocols` or `/protocols/run` to execute complex multi-step workflows.
 4. **Manage agent permissions** using `/users/me/agents` to restrict which agents may act on the user's behalf.
 

--- a/server/main.py
+++ b/server/main.py
@@ -14,6 +14,7 @@ from server.routers.jarvis import router as jarvis_router
 from server.routers.auth import router as auth_router
 from server.routers.protocols import router as protocol_router
 from server.routers.users import router as users_router
+from server.routers.agents import router as agents_router
 
 
 def create_app() -> FastAPI:
@@ -38,6 +39,7 @@ def create_app() -> FastAPI:
 
     # Include routers
     app.include_router(jarvis_router, prefix="/jarvis", tags=["jarvis"])
+    app.include_router(agents_router, prefix="/agents", tags=["agents"])
     app.include_router(auth_router, prefix="/auth", tags=["auth"])
     app.include_router(protocol_router, prefix="/protocols", tags=["protocols"])
     app.include_router(users_router, prefix="/users", tags=["users"])

--- a/server/routers/agents.py
+++ b/server/routers/agents.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from jarvis import JarvisSystem
+
+from ..dependencies import get_jarvis
+
+router = APIRouter()
+
+
+@router.get("/")
+async def list_agents(jarvis_system: JarvisSystem = Depends(get_jarvis)):
+    """Return all registered agents."""
+    return jarvis_system.list_agents()
+
+
+@router.get("/{agent_name}")
+async def get_agent(agent_name: str, jarvis_system: JarvisSystem = Depends(get_jarvis)):
+    """Return information about a single agent."""
+    agents = jarvis_system.list_agents()
+    if agent_name not in agents:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return agents[agent_name]
+
+
+@router.get("/{agent_name}/capabilities")
+async def get_agent_capabilities(agent_name: str, jarvis_system: JarvisSystem = Depends(get_jarvis)):
+    """List detailed capabilities for the given agent."""
+    return jarvis_system.get_agent_capabilities(agent_name)

--- a/server/routers/jarvis.py
+++ b/server/routers/jarvis.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from fastapi import APIRouter, Request, Depends
 from jarvis import JarvisSystem
 from jarvis.utils import detect_timezone
+from .agents import (
+    list_agents as list_agents_route,
+    get_agent_capabilities as agent_caps_route,
+)
 
 from ..models import JarvisRequest
 from ..dependencies import get_jarvis, get_user_allowed_agents
@@ -34,7 +38,7 @@ async def jarvis(
 @router.get("/agents")
 async def list_agents(jarvis_system: JarvisSystem = Depends(get_jarvis)):
     """List all available agents."""
-    return jarvis_system.list_agents()
+    return await list_agents_route(jarvis_system)
 
 
 @router.get("/agents/{agent_name}/capabilities")
@@ -42,4 +46,4 @@ async def get_agent_capabilities(
     agent_name: str, jarvis_system: JarvisSystem = Depends(get_jarvis)
 ):
     """Get all capabilities for a specific agent."""
-    return await jarvis_system.get_agent_capabilities(agent_name)
+    return await agent_caps_route(agent_name, jarvis_system)


### PR DESCRIPTION
## Summary
- expose agent info via new `/agents` router
- wire new router into the FastAPI app
- proxy `/jarvis/agents` through the new handlers
- document new endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6881d052dffc832a8df490cf7a5232d8