### PR TITLE
Filter protocols by active user agents

### DIFF
--- a/server/routers/protocols.py
+++ b/server/routers/protocols.py
@@ -14,10 +14,15 @@ router = APIRouter()
 @router.get("/")
 async def list_protocols(
     jarvis_system: JarvisSystem = Depends(get_jarvis),
+    allowed: set[str] | None = Depends(get_user_allowed_agents),
 ):
-    """Return all registered protocols with their details."""
+    """Return protocols that can be executed by the user."""
+    if not isinstance(allowed, set):
+        allowed_set = None
+    else:
+        allowed_set = allowed
     protocols = [
-        p.to_dict() for p in jarvis_system.protocol_registry.protocols.values()
+        p.to_dict() for p in jarvis_system.list_protocols(allowed_agents=allowed_set)
     ]
     return {"protocols": protocols}
 

--- a/tests/test_protocol_route.py
+++ b/tests/test_protocol_route.py
@@ -1,4 +1,5 @@
 import pytest
+from types import SimpleNamespace
 
 from server import list_protocols
 from jarvis.protocols.registry import ProtocolRegistry
@@ -8,6 +9,10 @@ from jarvis.protocols import Protocol
 class DummyJarvis:
     def __init__(self, registry):
         self.protocol_registry = registry
+        self.network = SimpleNamespace(agents={})
+
+    def list_protocols(self, allowed_agents=None):
+        return list(self.protocol_registry.protocols.values())
 
 
 @pytest.mark.asyncio

--- a/tests/test_protocol_visibility.py
+++ b/tests/test_protocol_visibility.py
@@ -1,0 +1,59 @@
+import pytest
+
+import server
+from jarvis.main_jarvis import JarvisSystem, JarvisConfig
+from jarvis.protocols import Protocol, ProtocolStep
+from jarvis.protocols.registry import ProtocolRegistry
+from jarvis.agents.agent_network import AgentNetwork
+from jarvis.agents.base import NetworkAgent
+from jarvis.logger import JarvisLogger
+
+
+class DummyAgent(NetworkAgent):
+    def __init__(self, name="dummy"):
+        super().__init__(name)
+        self.intent_map = {"do": self.do}
+
+    @property
+    def capabilities(self):
+        return {"do"}
+
+    async def do(self, **kwargs):
+        return {"done": True}
+
+
+@pytest.mark.asyncio
+async def test_list_protocols_filters_by_agents(tmp_path):
+    jarvis = JarvisSystem(JarvisConfig())
+    jarvis.logger = JarvisLogger()
+    jarvis.network = AgentNetwork(jarvis.logger)
+    jarvis.protocol_registry = ProtocolRegistry(db_path=str(tmp_path/"db.sqlite"), logger=jarvis.logger)
+
+    jarvis.network.register_agent(DummyAgent("dummy"))
+
+    proto_allowed = Protocol(
+        id="1",
+        name="Allowed",
+        description="",
+        steps=[ProtocolStep(agent="dummy", function="do", parameters={})],
+    )
+    proto_missing = Protocol(
+        id="2",
+        name="Missing",
+        description="",
+        steps=[ProtocolStep(agent="other", function="do", parameters={})],
+    )
+    jarvis.protocol_registry.register(proto_allowed)
+    jarvis.protocol_registry.register(proto_missing)
+
+    result = await server.list_protocols(jarvis)
+    names = {p["name"] for p in result["protocols"]}
+    assert "Allowed" in names
+    assert "Missing" not in names
+
+    result = await server.list_protocols(jarvis, {"dummy"})
+    names = [p["name"] for p in result["protocols"]]
+    assert names == ["Allowed"]
+
+    result = await server.list_protocols(jarvis, {"other"})
+    assert result["protocols"] == []


### PR DESCRIPTION
## Summary
- add `list_protocols` and optional agent filtering methods on `JarvisSystem`
- filter results in `/protocols` route based on allowed agents
- expose filtered protocols through `get_available_commands`
- adjust protocol route test for new method
- add new test ensuring protocols are hidden when required agents are missing or disabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881d9186820832a80154c700af86dac