### PR TITLE
Implement user profile persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ Each authenticated user may allow or deny individual agents. Use the following e
 
 Requests to `/jarvis` will only use agents that the user has allowed. If no preferences exist, all agents are considered allowed by default.
 
+### User profiles
+
+Jarvis now stores a profile for each authenticated user. The profile tracks the user's
+name, preferred personality, interests and other traits which are injected into prompts
+to personalize responses.
+
+Use the following endpoints to manage your profile:
+
+- `GET /users/me/profile` – retrieve the current profile data.
+- `POST /users/me/profile` – update profile fields by sending any subset of the profile attributes.
+
+When a `/jarvis` request is processed, the stored profile is included in the request
+metadata so agents can tailor their output to the user.
+
 ## Demo script
 
 Run the interactive demo from the command line:

--- a/jarvis/agents/chat_agent/__init__.py
+++ b/jarvis/agents/chat_agent/__init__.py
@@ -114,6 +114,7 @@ class ChatAgent(NetworkAgent):
         self.ai_client = ai_client
         # Aliases for backwards compatibility with older code
         self.user_profile = self.profile
+        self.current_user_id = None
         self.max_context_length = max_context_length
         self.memory_threshold = memory_threshold
 
@@ -568,6 +569,7 @@ Remember: You're not just answering questions - you're creating an engaging, per
             metadata = {
                 "type": "conversation",
                 "timestamp": conv_context.timestamp,
+                "user_id": self.current_user_id or -1,
                 "session_id": conv_context.session_id,
                 "personality_mode": conv_context.mood,
                 "topic": conv_context.topic or "general",

--- a/jarvis/main_jarvis.py
+++ b/jarvis/main_jarvis.py
@@ -21,6 +21,7 @@ from .agents.orchestrator_agent import OrchestratorAgent
 from .agents.weather_agent import WeatherAgent
 from .agents.memory_agent import MemoryAgent
 from .agents.chat_agent import ChatAgent
+from .profile import AgentProfile
 from .services.vector_memory import VectorMemoryService
 from .services.calendar_service import CalendarService
 from .services.canvas_service import CanvasService  # ← NEW
@@ -67,6 +68,7 @@ class JarvisSystem:
         self.protocol_agent: ProtocolAgent | None = None
         self.software_agent: SoftwareEngineeringAgent | None = None
         self.vector_memory: VectorMemoryService | None = None
+        self.user_profiles: dict[int, AgentProfile] = {}
 
         # Night mode management
         self.night_mode: bool = False
@@ -288,6 +290,19 @@ class JarvisSystem:
             tracker = PerfTracker(enabled=self.perf_enabled)
             tracker.start()
             new_tracker = True
+        if metadata:
+            user_id = metadata.get("user_id")
+            profile_data = metadata.get("profile")
+            profile_obj = None
+            if user_id is not None:
+                if profile_data is not None:
+                    profile_obj = AgentProfile(**profile_data)
+                    self.user_profiles[user_id] = profile_obj
+                else:
+                    profile_obj = self.user_profiles.get(user_id)
+                if profile_obj and self.chat_agent:
+                    self.chat_agent.profile = profile_obj
+                    self.chat_agent.current_user_id = user_id
         try:
             if not self.nlu_agent:
                 raise RuntimeError("System not initialized")

--- a/server/models.py
+++ b/server/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pydantic import BaseModel
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 
 class JarvisRequest(BaseModel):
@@ -17,3 +17,21 @@ class ProtocolRunRequest(BaseModel):
     protocol: Optional[Dict[str, Any]] = None
     protocol_name: Optional[str] = None
     arguments: Optional[Dict[str, Any]] = None
+
+
+class UserProfile(BaseModel):
+    name: Optional[str] = None
+    preferred_personality: Optional[str] = None
+    interests: Optional[List[str]] = None
+    conversation_style: Optional[str] = None
+    humor_preference: Optional[str] = None
+    topics_of_interest: Optional[List[str]] = None
+    language_preference: Optional[str] = None
+    interaction_count: Optional[int] = None
+    favorite_games: Optional[List[str]] = None
+    last_seen: Optional[str] = None
+    required_resources: Optional[List[str]] = None
+
+
+class UserProfileUpdate(UserProfile):
+    pass

--- a/server/routers/users.py
+++ b/server/routers/users.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 from ..dependencies import get_current_user, get_auth_db, get_user_allowed_agents, get_jarvis
-from ..database import set_user_agent_permissions, get_user_agent_permissions
+from ..database import (
+    set_user_agent_permissions,
+    get_user_agent_permissions,
+    get_user_profile,
+    set_user_profile,
+)
+from ..models import UserProfile, UserProfileUpdate
 from jarvis import JarvisSystem
 
 router = APIRouter()
@@ -34,4 +40,34 @@ async def set_my_agents(
     mapping = {name: True for name in allowed}
     mapping.update({name: False for name in disallowed})
     set_user_agent_permissions(db, current_user["id"], mapping)
+    return {"success": True}
+
+
+@router.get("/me/profile", response_model=UserProfile)
+async def get_my_profile(
+    current_user: dict = Depends(get_current_user),
+    db=Depends(get_auth_db),
+    jarvis: JarvisSystem = Depends(get_jarvis),
+):
+    profile = get_user_profile(db, current_user["id"])
+    if profile:
+        jarvis.user_profiles[current_user["id"]] = jarvis.user_profiles.get(
+            current_user["id"],
+            jarvis.chat_agent.profile.__class__(**profile),
+        )
+    return profile or {}
+
+
+@router.post("/me/profile")
+async def update_my_profile(
+    body: UserProfileUpdate,
+    current_user: dict = Depends(get_current_user),
+    db=Depends(get_auth_db),
+    jarvis: JarvisSystem = Depends(get_jarvis),
+):
+    set_user_profile(db, current_user["id"], body.dict(exclude_unset=True))
+    profile = get_user_profile(db, current_user["id"])
+    jarvis.user_profiles[current_user["id"]] = jarvis.chat_agent.profile.__class__(
+        **profile
+    )
     return {"success": True}

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -5,23 +5,30 @@ from httpx import ASGITransport
 
 import server
 
+
 class DummyJarvis:
     def __init__(self):
-        self.last_allowed = None
+        self.last_metadata = None
+
     async def process_request(self, command, tz, metadata, allowed_agents=None):
-        self.last_allowed = allowed_agents
-        return {"response": "done"}
+        self.last_metadata = metadata
+        return {"response": "ok"}
+
     def list_agents(self):
-        return {"A": {}, "B": {}}
+        return {"A": {}}
+
 
 @pytest.mark.asyncio
-async def test_agent_preferences_endpoints(tmp_path):
+async def test_user_profile_endpoints(tmp_path):
     db = sqlite3.connect(tmp_path / "auth.db", check_same_thread=False)
     db.execute(
         "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT UNIQUE, password_hash TEXT)"
     )
     db.execute(
         "CREATE TABLE user_agents (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, agent_name TEXT, allowed INTEGER, UNIQUE(user_id, agent_name))"
+    )
+    db.execute(
+        "CREATE TABLE user_profiles (user_id INTEGER PRIMARY KEY, name TEXT, preferred_personality TEXT, interests TEXT, conversation_style TEXT, humor_preference TEXT, topics_of_interest TEXT, language_preference TEXT, interaction_count INTEGER DEFAULT 0, favorite_games TEXT, last_seen TEXT, required_resources TEXT)"
     )
     db.commit()
 
@@ -30,25 +37,30 @@ async def test_agent_preferences_endpoints(tmp_path):
     server.app.state.auth_db = db
 
     jarvis = DummyJarvis()
+
     async def override_get_jarvis():
         return jarvis
+
     server.app.dependency_overrides[server.get_jarvis] = override_get_jarvis
 
     transport = ASGITransport(app=server.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.post("/auth/signup", json={"email": "u@test.com", "password": "pw"})
+        resp = await client.post("/auth/signup", json={"email": "p@test.com", "password": "pw"})
         token = resp.json()["token"]
         headers = {"Authorization": f"Bearer {token}"}
+
         resp = await client.post(
-            "/users/me/agents", json={"allowed": ["A"], "disallowed": ["B"]}, headers=headers
+            "/users/me/profile",
+            json={"name": "Alice", "interests": ["ai"]},
+            headers=headers,
         )
         assert resp.status_code == 200
-        resp = await client.get("/users/me/agents", headers=headers)
-        assert resp.json()["allowed"] == ["A"]
-        assert resp.json()["disallowed"] == ["B"]
 
-        await client.post("/jarvis/", json={"command": "test"}, headers=headers)
-        assert jarvis.last_allowed == {"A"}
+        resp = await client.get("/users/me/profile", headers=headers)
+        assert resp.json()["name"] == "Alice"
+        assert resp.json()["interests"] == ["ai"]
+
+        await client.post("/jarvis/", json={"command": "hi"}, headers=headers)
+        assert jarvis.last_metadata["profile"]["name"] == "Alice"
 
     db.close()
-


### PR DESCRIPTION
## Summary
- add user profile table and helpers
- expose profile endpoints
- load profiles in /jarvis requests
- track current user on ChatAgent and tag stored memory
- document new profile features
- include basic regression tests

## Testing
- `pytest tests/test_user_profile.py tests/test_user_agent_permissions.py -q` *(fails: no such table: user_profiles)*

------
https://chatgpt.com/codex/tasks/task_e_6881cf1cab60832aa7f20e5c9e3cffeb