### PR TITLE
Introduce shared registry base class

### DIFF
--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -20,6 +20,7 @@ except Exception:  # pragma: no cover - optional dependency may be missing
     create_collaborative_jarvis = None
 from .protocols import Protocol, ProtocolStep
 from .protocols.registry import ProtocolRegistry
+from .registry import BaseRegistry, FunctionRegistry
 from .protocols.executor import ProtocolExecutor
 from .protocols.builder import create_from_file
 from .constants import (
@@ -49,6 +50,8 @@ __all__ = [
     "Protocol",
     "ProtocolStep",
     "ProtocolRegistry",
+    "BaseRegistry",
+    "FunctionRegistry",
     "ProtocolExecutor",
     "create_from_file",
     "DEFAULT_PORT",

--- a/jarvis/agents/calendar_agent/function_registry.py
+++ b/jarvis/agents/calendar_agent/function_registry.py
@@ -1,14 +1,15 @@
 # jarvis/agents/calendar_agent/function_registry.py
-from typing import Dict, Callable, Any, Set
+from typing import Dict, Callable
 from ...services.calendar_service import CalendarService
+from ...registry import FunctionRegistry
 
 
-class CalendarFunctionRegistry:
+class CalendarFunctionRegistry(FunctionRegistry):
     """Unified registry for calendar functions and capabilities"""
 
     def __init__(self, calendar_service: CalendarService):
         self.calendar_service = calendar_service
-        self._function_map = self._build_function_map()
+        super().__init__(self._build_function_map())
 
     def _build_function_map(self) -> Dict[str, Callable]:
         """Build the mapping of function names to calendar service methods"""
@@ -90,31 +91,3 @@ class CalendarFunctionRegistry:
             "check_busy_days": self.calendar_service.get_busy_days,
         }
 
-    @property
-    def functions(self) -> Dict[str, Callable]:
-        """Get the function mapping"""
-        return self._function_map
-
-    @property
-    def capabilities(self) -> Set[str]:
-        """Get capabilities as a set of all function names"""
-        return set(self._function_map.keys())
-
-    def get_function(self, function_name: str) -> Callable | None:
-        """Get a specific function by name"""
-        return self._function_map.get(function_name)
-
-    def has_function(self, function_name: str) -> bool:
-        """Check if a function exists"""
-        return function_name in self._function_map
-
-    def add_function(self, name: str, func: Callable) -> None:
-        """Add a new function to the registry"""
-        self._function_map[name] = func
-
-    def remove_function(self, name: str) -> bool:
-        """Remove a function from the registry"""
-        if name in self._function_map:
-            del self._function_map[name]
-            return True
-        return False

--- a/jarvis/agents/weather_agent/function_registry.py
+++ b/jarvis/agents/weather_agent/function_registry.py
@@ -1,14 +1,15 @@
 # jarvis/agents/weather_agent/function_registry.py
-from typing import Dict, Callable, Set
+from typing import Dict, Callable
 from ...services.weather_service import WeatherService
+from ...registry import FunctionRegistry
 
 
-class WeatherFunctionRegistry:
+class WeatherFunctionRegistry(FunctionRegistry):
     """Unified registry for weather functions and capabilities"""
 
     def __init__(self, weather_service: WeatherService):
         self.weather_service = weather_service
-        self._function_map = self._build_function_map()
+        super().__init__(self._build_function_map())
 
     def _build_function_map(self) -> Dict[str, Callable]:
         """Build the mapping of function names to weather service methods"""
@@ -30,31 +31,3 @@ class WeatherFunctionRegistry:
             "air_quality": self.weather_service.get_air_quality,
         }
 
-    @property
-    def functions(self) -> Dict[str, Callable]:
-        """Get the function mapping"""
-        return self._function_map
-
-    @property
-    def capabilities(self) -> Set[str]:
-        """Get capabilities as a set of all function names"""
-        return set(self._function_map.keys())
-
-    def get_function(self, function_name: str) -> Callable | None:
-        """Get a specific function by name"""
-        return self._function_map.get(function_name)
-
-    def has_function(self, function_name: str) -> bool:
-        """Check if a function exists"""
-        return function_name in self._function_map
-
-    def add_function(self, name: str, func: Callable) -> None:
-        """Add a new function to the registry"""
-        self._function_map[name] = func
-
-    def remove_function(self, name: str) -> bool:
-        """Remove a function from the registry"""
-        if name in self._function_map:
-            del self._function_map[name]
-            return True
-        return False

--- a/jarvis/protocols/registry.py
+++ b/jarvis/protocols/registry.py
@@ -9,10 +9,11 @@ from concurrent.futures import ThreadPoolExecutor
 import concurrent.futures
 
 from ..logger import JarvisLogger
+from ..registry import BaseRegistry
 from .models import Protocol, ProtocolStep, ProtocolResponse
 
 
-class ProtocolRegistry:
+class ProtocolRegistry(BaseRegistry[Protocol]):
     """Stores and retrieves Protocol definitions using SQLite."""
 
     def __init__(
@@ -23,7 +24,9 @@ class ProtocolRegistry:
         self.conn: sqlite3.Connection = sqlite3.connect(self.db_path)
         self.conn.row_factory = sqlite3.Row
         self._ensure_table()
-        self.protocols: Dict[str, Protocol] = {}
+        super().__init__({})
+        # Alias for backward compatibility
+        self.protocols = self._items
         self.load()
 
     def _ensure_table(self) -> None:

--- a/jarvis/registry.py
+++ b/jarvis/registry.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, Generic, Optional, Set, TypeVar
+
+T = TypeVar("T")
+
+
+class BaseRegistry(Generic[T]):
+    """Generic registry storing items by name."""
+
+    def __init__(self, initial_map: Optional[Dict[str, T]] = None) -> None:
+        self._items: Dict[str, T] = initial_map or {}
+
+    @property
+    def items(self) -> Dict[str, T]:
+        """Return the underlying mapping."""
+        return self._items
+
+    @property
+    def keys(self) -> Set[str]:
+        """Return the registry keys."""
+        return set(self._items.keys())
+
+    def get(self, name: str) -> Optional[T]:
+        """Retrieve a registered item by name."""
+        return self._items.get(name)
+
+    def has(self, name: str) -> bool:
+        """Check if the registry contains an item."""
+        return name in self._items
+
+    def add(self, name: str, item: T) -> None:
+        """Add an item to the registry."""
+        self._items[name] = item
+
+    def remove(self, name: str) -> bool:
+        """Remove an item from the registry."""
+        if name in self._items:
+            del self._items[name]
+            return True
+        return False
+
+
+class FunctionRegistry(BaseRegistry[Callable]):
+    """Registry specialised for callables used by agents."""
+
+    @property
+    def functions(self) -> Dict[str, Callable]:
+        return self.items
+
+    @property
+    def capabilities(self) -> Set[str]:
+        return self.keys
+
+    def get_function(self, name: str) -> Optional[Callable]:
+        return self.get(name)
+
+    def has_function(self, name: str) -> bool:
+        return self.has(name)
+
+    def add_function(self, name: str, func: Callable) -> None:
+        self.add(name, func)
+
+    def remove_function(self, name: str) -> bool:
+        return self.remove(name)


### PR DESCRIPTION
## Summary
- create `BaseRegistry` and `FunctionRegistry`
- refactor calendar and weather function registries to inherit from `FunctionRegistry`
- refactor `ProtocolRegistry` to extend `BaseRegistry`
- expose new classes in package `__all__`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'ChatAgent')*

------
https://chatgpt.com/codex/tasks/task_e_6882efa46900832aae079a7a4414f1d6