### PR TITLE
Implement encrypted user config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Additional Python packages used by the project:
 - `chromadb`
 - `passlib[bcrypt]`
 - `PyJWT`
+- `cryptography`
 
 ## Overview
 - **Language**: Python 3.11+

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Create a `.env` file or export the following variables before running the server
 - `CALENDAR_API_URL` – base URL of the calendar API (defaults to `http://localhost:8080`)
 - `REPO_PATH` – path to the repository used by the SoftwareEngineeringAgent (defaults to `.`)
 - `WEATHER_API_KEY` – API key for OpenWeatherMap used by `WeatherAgent`
+- `CONFIG_SECRET` – 32-byte base64 key used to encrypt user configuration
 
 ## Running the server
 
@@ -62,6 +63,8 @@ Use the following endpoints to manage your profile:
 
 - `GET /users/me/profile` – retrieve the current profile data.
 - `POST /users/me/profile` – update profile fields by sending any subset of the profile attributes.
+- `GET /users/me/config` – fetch your stored API keys and service settings.
+- `POST /users/me/config` – update any of those configuration values.
 
 When a `/jarvis` request is processed, the stored profile is included in the request
 metadata so agents can tailor their output to the user.

--- a/jarvis/config.py
+++ b/jarvis/config.py
@@ -17,6 +17,21 @@ class JarvisConfig:
     intent_timeout: float = 5.0
     perf_tracking: bool = True
     memory_dir: Optional[str] = None
+    weather_api_key: Optional[str] = None
+    hue_bridge_ip: Optional[str] = None
+    hue_username: Optional[str] = None
     # perf_tracking: bool = os.getenv(
     #     "PERF_TRACE", os.getenv("PERF_TRACKING", "false")
     # ).lower() == "true"
+
+
+@dataclass
+class UserConfig:
+    """Per-user configuration values stored in the database."""
+
+    openai_api_key: Optional[str] = None
+    anthropic_api_key: Optional[str] = None
+    calendar_api_url: Optional[str] = None
+    weather_api_key: Optional[str] = None
+    hue_bridge_ip: Optional[str] = None
+    hue_username: Optional[str] = None

--- a/jarvis/main_jarvis.py
+++ b/jarvis/main_jarvis.py
@@ -152,7 +152,11 @@ class JarvisSystem:
         self.network.register_agent(self.chat_agent)
 
     def _create_weather_agent(self, ai_client: BaseAIClient) -> None:
-        weather_key = os.getenv("WEATHER_API_KEY") or os.getenv("OPENWEATHER_API_KEY")
+        weather_key = (
+            self.config.weather_api_key
+            or os.getenv("WEATHER_API_KEY")
+            or os.getenv("OPENWEATHER_API_KEY")
+        )
         try:
             self.weather_agent = WeatherAgent(
                 api_key=weather_key, logger=self.logger, ai_client=ai_client
@@ -167,8 +171,12 @@ class JarvisSystem:
 
     def _create_lights_agent(self, ai_client: BaseAIClient) -> None:
         load_dotenv()
-        bridge_ip = os.getenv("HUE_BRIDGE_IP")
-        self.lights_agent = PhillipsHueAgent(ai_client=ai_client, bridge_ip=bridge_ip)
+        bridge_ip = self.config.hue_bridge_ip or os.getenv("HUE_BRIDGE_IP")
+        self.lights_agent = PhillipsHueAgent(
+            ai_client=ai_client,
+            bridge_ip=bridge_ip,
+            username=self.config.hue_username,
+        )
         self.network.register_agent(self.lights_agent)
 
     def _create_software_agent(self, ai_client: BaseAIClient) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -138,3 +138,4 @@ passlib[bcrypt]
 passlib
 PyJWT
 
+cryptography

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -2,7 +2,7 @@
 
 from .main import app
 from .auth import pwd_context
-from .dependencies import get_jarvis
+from .dependencies import get_jarvis, get_user_jarvis
 from .routers.protocols import list_protocols
 
-__all__ = ["app", "pwd_context", "get_jarvis", "list_protocols"]
+__all__ = ["app", "pwd_context", "get_jarvis", "get_user_jarvis", "list_protocols"]

--- a/server/crypto.py
+++ b/server/crypto.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+from cryptography.fernet import Fernet, InvalidToken
+
+
+_SECRET = os.getenv("CONFIG_SECRET")
+if not _SECRET:
+    # Generate a key if not provided to avoid crashes in dev/test
+    _SECRET = Fernet.generate_key().decode()
+    os.environ["CONFIG_SECRET"] = _SECRET
+
+fernet = Fernet(_SECRET)
+
+
+def encrypt(value: str | None) -> str:
+    """Encrypt a string value."""
+    if value is None:
+        return ""
+    return fernet.encrypt(value.encode()).decode()
+
+
+def decrypt(value: str | None) -> str:
+    """Decrypt a previously encrypted string."""
+    if not value:
+        return ""
+    try:
+        return fernet.decrypt(value.encode()).decode()
+    except InvalidToken:
+        return ""

--- a/server/dependencies.py
+++ b/server/dependencies.py
@@ -4,7 +4,8 @@ import sqlite3
 from fastapi import Request, HTTPException, Depends
 from jarvis import JarvisSystem
 from .auth import decode_token
-from .database import get_user_agent_permissions
+from .database import get_user_agent_permissions, get_user_config
+from jarvis import JarvisConfig
 
 
 async def get_jarvis(request: Request) -> JarvisSystem:
@@ -47,3 +48,47 @@ async def get_user_allowed_agents(
         # default allow all agents
         return set(jarvis.list_agents().keys())
     return {name for name, allowed in mapping.items() if allowed}
+
+
+async def get_user_jarvis(
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+    db: sqlite3.Connection = Depends(get_auth_db),
+) -> JarvisSystem:
+    """Return a JarvisSystem configured for the current user."""
+    systems = getattr(request.app.state, "user_systems", None)
+    if systems is None:
+        systems = {}
+        request.app.state.user_systems = systems
+
+    jarvis = systems.get(current_user["id"])
+    if jarvis is not None:
+        return jarvis
+
+    base: JarvisSystem | None = getattr(request.app.state, "jarvis_system", None)
+    if base is None:
+        raise HTTPException(status_code=500, detail="Jarvis system not initialized")
+
+    user_conf = get_user_config(db, current_user["id"])
+    config = JarvisConfig(
+        ai_provider=base.config.ai_provider,
+        api_key=(
+            user_conf.get("openai_api_key")
+            or user_conf.get("anthropic_api_key")
+            or base.config.api_key
+        ),
+        calendar_api_url=user_conf.get("calendar_api_url") or base.config.calendar_api_url,
+        repo_path=base.config.repo_path,
+        response_timeout=base.config.response_timeout,
+        intent_timeout=base.config.intent_timeout,
+        perf_tracking=base.config.perf_tracking,
+        memory_dir=base.config.memory_dir,
+        weather_api_key=user_conf.get("weather_api_key") or base.config.weather_api_key,
+        hue_bridge_ip=user_conf.get("hue_bridge_ip") or base.config.hue_bridge_ip,
+        hue_username=user_conf.get("hue_username") or base.config.hue_username,
+    )
+
+    jarvis = JarvisSystem(config)
+    await jarvis.initialize()
+    systems[current_user["id"]] = jarvis
+    return jarvis

--- a/server/main.py
+++ b/server/main.py
@@ -64,6 +64,7 @@ def create_app() -> FastAPI:
         jarvis_system = JarvisSystem(config)
         await jarvis_system.initialize()
         app.state.jarvis_system = jarvis_system
+        app.state.user_systems = {}
 
         # Initialize database
         app.state.auth_db = init_database()

--- a/server/models.py
+++ b/server/models.py
@@ -35,3 +35,16 @@ class UserProfile(BaseModel):
 
 class UserProfileUpdate(UserProfile):
     pass
+
+
+class UserConfig(BaseModel):
+    openai_api_key: Optional[str] = None
+    anthropic_api_key: Optional[str] = None
+    calendar_api_url: Optional[str] = None
+    weather_api_key: Optional[str] = None
+    hue_bridge_ip: Optional[str] = None
+    hue_username: Optional[str] = None
+
+
+class UserConfigUpdate(UserConfig):
+    pass

--- a/server/routers/jarvis.py
+++ b/server/routers/jarvis.py
@@ -11,6 +11,7 @@ from .agents import (
 from ..models import JarvisRequest
 from ..dependencies import (
     get_jarvis,
+    get_user_jarvis,
     get_user_allowed_agents,
     get_current_user,
     get_auth_db,
@@ -25,7 +26,7 @@ router = APIRouter()
 async def jarvis(
     req: JarvisRequest,
     request: Request,
-    jarvis_system: JarvisSystem = Depends(get_jarvis),
+    jarvis_system: JarvisSystem = Depends(get_user_jarvis),
     allowed: set[str] = Depends(get_user_allowed_agents),
     current_user: dict = Depends(get_current_user),
     db=Depends(get_auth_db),

--- a/tests/test_api_run_protocol.py
+++ b/tests/test_api_run_protocol.py
@@ -42,6 +42,7 @@ async def test_run_protocol_endpoint(tmp_path):
         return jarvis
 
     server.app.dependency_overrides[server.get_jarvis] = override_get_jarvis
+    server.app.dependency_overrides[server.get_user_jarvis] = override_get_jarvis
     server.app.dependency_overrides[get_user_allowed_agents] = lambda: {"dummy"}
 
     proto = Protocol(

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,11 @@
+import os
+from server.crypto import encrypt, decrypt
+
+
+def test_encrypt_decrypt_roundtrip():
+    os.environ['CONFIG_SECRET'] = os.environ.get('CONFIG_SECRET', 'a'*44)
+    secret = 'secret-value'
+    enc = encrypt(secret)
+    assert enc != secret
+    dec = decrypt(enc)
+    assert dec == secret

--- a/tests/test_permission_enforcement.py
+++ b/tests/test_permission_enforcement.py
@@ -48,6 +48,7 @@ async def test_protocol_run_disallowed_agent(tmp_path):
         return {"other"}
 
     server.app.dependency_overrides[server.get_jarvis] = override_get_jarvis
+    server.app.dependency_overrides[server.get_user_jarvis] = override_get_jarvis
     server.app.dependency_overrides[get_user_allowed_agents] = override_allowed
 
     proto = Protocol(
@@ -97,6 +98,7 @@ async def test_voice_trigger_disallowed_agent(tmp_path):
         return {"other"}
 
     server.app.dependency_overrides[server.get_jarvis] = override_get_jarvis
+    server.app.dependency_overrides[server.get_user_jarvis] = override_get_jarvis
     server.app.dependency_overrides[get_user_allowed_agents] = override_allowed
 
     server.app.router.on_startup.clear()

--- a/tests/test_user_agent_permissions.py
+++ b/tests/test_user_agent_permissions.py
@@ -33,6 +33,7 @@ async def test_agent_preferences_endpoints(tmp_path):
     async def override_get_jarvis():
         return jarvis
     server.app.dependency_overrides[server.get_jarvis] = override_get_jarvis
+    server.app.dependency_overrides[server.get_user_jarvis] = override_get_jarvis
 
     transport = ASGITransport(app=server.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -1,0 +1,48 @@
+import sqlite3
+import httpx
+import pytest
+from httpx import ASGITransport
+
+import server
+
+
+class DummyJarvis:
+    async def process_request(self, command, tz, metadata, allowed_agents=None):
+        return {"ok": True}
+
+    def list_agents(self):
+        return {"A": {}}
+
+
+@pytest.mark.asyncio
+async def test_user_config_crud(tmp_path):
+    db = sqlite3.connect(tmp_path / "auth.db", check_same_thread=False)
+    db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT UNIQUE, password_hash TEXT)")
+    db.execute("CREATE TABLE user_configs (user_id INTEGER PRIMARY KEY, openai_api_key TEXT, anthropic_api_key TEXT, calendar_api_url TEXT, weather_api_key TEXT, hue_bridge_ip TEXT, hue_username TEXT)")
+    db.commit()
+
+    server.app.router.on_startup.clear()
+    server.app.router.on_shutdown.clear()
+    server.app.state.auth_db = db
+
+    jarvis = DummyJarvis()
+    async def override_get_jarvis():
+        return jarvis
+
+    server.app.dependency_overrides[server.get_user_jarvis] = override_get_jarvis
+    server.app.dependency_overrides[server.get_jarvis] = override_get_jarvis
+
+    transport = ASGITransport(app=server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/auth/signup", json={"email": "c@test.com", "password": "pw"})
+        token = resp.json()["token"]
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = await client.post("/users/me/config", json={"calendar_api_url": "http://x"}, headers=headers)
+        assert resp.status_code == 200
+
+        resp = await client.get("/users/me/config", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["calendar_api_url"] == "http://x"
+
+    db.close()

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -42,6 +42,7 @@ async def test_user_profile_endpoints(tmp_path):
         return jarvis
 
     server.app.dependency_overrides[server.get_jarvis] = override_get_jarvis
+    server.app.dependency_overrides[server.get_user_jarvis] = override_get_jarvis
 
     transport = ASGITransport(app=server.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:


### PR DESCRIPTION
## Summary
- allow configuring API keys and services per-user
- encrypt config values with Fernet
- expose `/users/me/config` endpoints for CRUD
- load user settings in a new `get_user_jarvis` dependency
- document `CONFIG_SECRET` env var and new API routes
- add dependency on `cryptography`

## Testing
- `pip install -q --use-deprecated=legacy-resolver -r requirements.txt` *(fails: dependency conflicts)*
- `pytest -q` *(fails: ImportError from pydantic_core)*

------
https://chatgpt.com/codex/tasks/task_e_68885dc84014832abfc30eee9b1e0311