### PR TITLE
Add audio processing dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,10 @@ Additional Python packages used by the project:
 - `passlib[bcrypt]`
 - `PyJWT`
 - `cryptography`
+- `sounddevice`
+- `soundfile`
+
+`sounddevice` and `soundfile` depend on the system libraries PortAudio and libsndfile respectively. Ensure these libraries are installed in runtime environments.
 
 ## Overview
 - **Language**: Python 3.11+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,6 @@ tzlocal
 motor
 phue
 colorama
+sounddevice
+soundfile
 


### PR DESCRIPTION
## Summary
- add sounddevice and soundfile to requirements
- document audio package requirements and system libraries

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68997e0e1100832a851d4193d743db6c