### PR TITLE
Restore protocol runtime setup helper

### DIFF
--- a/jarvis/main_jarvis.py
+++ b/jarvis/main_jarvis.py
@@ -245,6 +245,18 @@ class JarvisSystem:
             return []
         return self.protocol_runtime.list_protocols(allowed_agents)
 
+    def _setup_protocol_system(self, load_protocol_directory: bool = False) -> None:
+        """Initialize the protocol runtime and related helpers."""
+        self.protocol_runtime = ProtocolRuntime(
+            self.network, self.logger, usage_logger=self.usage_logger
+        )
+        self.protocol_runtime.initialize(
+            load_protocol_directory,
+            Path(__file__).parent / "protocols" / "defaults" / "definitions",
+        )
+        self.protocol_registry = self.protocol_runtime.registry
+        self.voice_matcher = self.protocol_runtime.voice_matcher
+
     async def _start_network(self) -> None:
         await self.network.start()
 


### PR DESCRIPTION
## Summary
- reintroduce `_setup_protocol_system` in `JarvisSystem` to initialize protocol runtime and registry

## Testing
- `pytest` *(fails: ERROR tests/test_api_run_protocol.py, tests/test_auth_api.py, tests/test_crypto.py, tests/test_permission_enforcement.py, tests/test_protocol_route.py, tests/test_protocol_visibility.py, tests/test_user_agent_permissions.py, tests/test_user_config.py, tests/test_user_profile.py, tests/test_voice_system.py)*

------
https://chatgpt.com/codex/tasks/task_e_689c02675bac832a83dfa1a671a1ba94