### PR TITLE
docs: reference server main module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,11 +37,11 @@ Additional Python packages used by the project:
   - `jarvis/ai_clients/` – wrappers for OpenAI and Anthropic APIs.
   - `jarvis/services/` – service layer utilities like the calendar API client.
   - `jarvis/logger.py` – writes logs to stdout and SQLite.
-  - `server.py` – FastAPI entrypoint exposing the `/jarvis` endpoint.
+  - `server/main.py` – FastAPI entrypoint exposing the `/jarvis` endpoint. Run with `python -m server.main`.
 
 ## Running the server
 ```bash
-python server.py
+python -m server.main
 ```
 The API will listen on port 8000.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Create a `.env` file or export the following variables before running the server
 Start the FastAPI application on port 8000:
 
 ```bash
-python server.py
+python -m server.main
 ```
 
 The `/jarvis` endpoint accepts a JSON body with a `command` field describing the calendar request.
@@ -142,7 +142,7 @@ results = await executor.execute(proto, {"name": "Alice"})
 ## Project structure
 
 - `jarvis/` – main package with agent implementations and utilities
-- `server.py` – FastAPI entrypoint
+- `server/main.py` – FastAPI entrypoint (run with `python -m server.main`)
 - `main.py` – simple demo using `create_collaborative_jarvis`
 
 ## Running tests

--- a/docs/frontend_implementation.md
+++ b/docs/frontend_implementation.md
@@ -9,7 +9,7 @@ The FastAPI server exposes collaborative AI agents that can process natural lang
 Start the server with:
 
 ```bash
-python server.py
+python -m server.main
 ```
 
 The default port is `8000`.


### PR DESCRIPTION
## Summary
- document new server entrypoint `python -m server.main` in README, AGENTS, and frontend guide
- update project structure to point to `server/main.py`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'chromadb')*

------
https://chatgpt.com/codex/tasks/task_e_689c268422d4832abf3cdff428465c9a