### PR TITLE
Require JWT secret for auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Create a `.env` file or export the following variables before running the server
 - `REPO_PATH` – path to the repository used by the SoftwareEngineeringAgent (defaults to `.`)
 - `WEATHER_API_KEY` – API key for OpenWeatherMap used by `WeatherAgent`
 - `CONFIG_SECRET` – 32-byte base64 key used to encrypt user configuration
+- `JWT_SECRET` – secret key for signing authentication tokens (required)
+- `PHILLIPS_HUE_BRIDGE_IP` – IP address of the Philips Hue Bridge for light control (optional)
 
 ## Running the server
 

--- a/jarvis/builder.py
+++ b/jarvis/builder.py
@@ -1,6 +1,7 @@
 # jarvis/app/builder.py
 
 from __future__ import annotations
+import logging
 import os
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
@@ -101,6 +102,10 @@ class JarvisBuilder:
         hue_bridge_ip = os.getenv(hue_bridge_ip_env)
         if not api_key:
             raise ValueError(f"Missing API key. Set {api_key_env} in your environment.")
+        if not hue_bridge_ip:
+            logging.getLogger("jarvis").info(
+                "%s not set; Philips Hue integration disabled", hue_bridge_ip_env
+            )
 
         cfg = JarvisConfig(
             ai_provider=ai_provider,

--- a/server/auth.py
+++ b/server/auth.py
@@ -26,7 +26,9 @@ except (ImportError, AttributeError):
 # This is still cryptographically secure and more reliable
 pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 
-JWT_SECRET = os.getenv("JWT_SECRET", "secret")
+JWT_SECRET = os.getenv("JWT_SECRET")
+if not JWT_SECRET:
+    raise RuntimeError("JWT_SECRET environment variable must be set")
 JWT_ALGORITHM = "HS256"
 TOKEN_EXPIRE_MINUTES = int(os.getenv("TOKEN_EXPIRE_MINUTES", 60))
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+import os
+
+# Default secret for tests; real deployments must provide JWT_SECRET
+os.environ.setdefault("JWT_SECRET", "testing-secret")

--- a/tests/test_missing_jwt_secret.py
+++ b/tests/test_missing_jwt_secret.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+import sys
+
+
+def test_missing_jwt_secret():
+    env = os.environ.copy()
+    env.pop("JWT_SECRET", None)
+    cmd = (
+        "import importlib.util, pathlib;"
+        "spec=importlib.util.spec_from_file_location('auth', pathlib.Path('server')/'auth.py');"
+        "mod=importlib.util.module_from_spec(spec);"
+        "spec.loader.exec_module(mod)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", cmd],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "JWT_SECRET" in result.stderr


### PR DESCRIPTION
## Summary
- Fail fast if `JWT_SECRET` environment variable is unset
- Document `JWT_SECRET` as required for running the server
- Test import error when `JWT_SECRET` is missing
- Document optional `PHILLIPS_HUE_BRIDGE_IP` and log when Hue bridge is not configured

## Testing
- `pytest tests/test_missing_jwt_secret.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_689c26986e08832aabee966ff9277317