### PR TITLE
refactor: reuse protocol setup

### DIFF
--- a/jarvis/core/builder.py
+++ b/jarvis/core/builder.py
@@ -171,7 +171,9 @@ class JarvisBuilder:
         jarvis.night_agents = refs.get("night_agents", [])
 
         # Protocol runtime (matcher/executor) + optional file loading
-        jarvis._setup_protocol_system(self._opts.load_protocol_directory)
+        jarvis._setup_protocol_system(
+            load_protocol_directory=self._opts.load_protocol_directory
+        )
 
         # Start network
         await jarvis._start_network()

--- a/jarvis/core/system.py
+++ b/jarvis/core/system.py
@@ -85,15 +85,7 @@ class JarvisSystem:
         self.night_controller = refs.get("night_controller")
         self.night_agents = refs.get("night_agents", [])
 
-        self.protocol_runtime = ProtocolRuntime(
-            self.network, self.logger, usage_logger=self.usage_logger
-        )
-        self.protocol_runtime.initialize(
-            load_protocol_directory,
-            Path(__file__).parent / "protocols" / "defaults" / "definitions",
-        )
-        self.protocol_registry = self.protocol_runtime.registry
-        self.voice_matcher = self.protocol_runtime.voice_matcher
+        self._setup_protocol_system(load_protocol_directory)
         await self._start_network()
 
         loaded = (
@@ -151,15 +143,20 @@ class JarvisSystem:
             return []
         return self.protocol_runtime.list_protocols(allowed_agents)
 
-    def _setup_protocol_system(self, load_protocol_directory: bool = False) -> None:
+    def _setup_protocol_system(
+        self,
+        load_protocol_directory: bool = False,
+        definition_dir: Path | None = None,
+    ) -> None:
         """Initialize the protocol runtime and related helpers."""
+        if definition_dir is None:
+            definition_dir = (
+                Path(__file__).parent / "protocols" / "defaults" / "definitions"
+            )
         self.protocol_runtime = ProtocolRuntime(
             self.network, self.logger, usage_logger=self.usage_logger
         )
-        self.protocol_runtime.initialize(
-            load_protocol_directory,
-            Path(__file__).parent / "protocols" / "defaults" / "definitions",
-        )
+        self.protocol_runtime.initialize(load_protocol_directory, definition_dir)
         self.protocol_registry = self.protocol_runtime.registry
         self.voice_matcher = self.protocol_runtime.voice_matcher
 


### PR DESCRIPTION
## Summary
- call `_setup_protocol_system` from `JarvisSystem.initialize` to remove duplicated protocol wiring
- allow `_setup_protocol_system` to accept a custom definition directory and expose keyword in builder

## Testing
- `pytest` *(fails: AttributeError in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_689c30ea77a4832a950a96efbaa589f6