### PR TITLE
Add InstructionProtocol for building protocol steps

### DIFF
--- a/jarvis/protocols/__init__.py
+++ b/jarvis/protocols/__init__.py
@@ -8,6 +8,7 @@ from .models import (
     ProtocolResponse,
     ResponseMode,
 )
+from .instruction_protocol import InstructionProtocol
 from .loggers import (
     ProtocolUsageLogger,
     ExecutionMetadata,
@@ -23,6 +24,7 @@ __all__ = [
     "ArgumentType",
     "ProtocolResponse",
     "ResponseMode",
+    "InstructionProtocol",
     "ProtocolUsageLogger",
     "ExecutionMetadata",
     "ProtocolLogEntry",

--- a/jarvis/protocols/instruction_protocol.py
+++ b/jarvis/protocols/instruction_protocol.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from .models import Protocol, ProtocolStep
+
+
+@dataclass
+class InstructionProtocol(Protocol):
+    """Protocol with convenience method for adding steps."""
+
+    def add_step(
+        self,
+        agent: str,
+        function: str,
+        params: Dict[str, Any],
+        mappings: Dict[str, str] | None = None,
+    ) -> None:
+        """Append a ``ProtocolStep`` to the protocol."""
+        self.steps.append(
+            ProtocolStep(
+                agent=agent,
+                function=function,
+                parameters=params,
+                parameter_mappings=mappings or {},
+            )
+        )


### PR DESCRIPTION
## Summary
- implement InstructionProtocol with `add_step` helper to append ProtocolSteps
- expose InstructionProtocol from protocols package

## Testing
- `python -m py_compile jarvis/protocols/instruction_protocol.py`
- `pytest` *(fails: KeyError 'jarvis', 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689e75c73178832a88baca8f828a902c