### PR TITLE
Add MethodRecorder for protocol step recording

### DIFF
--- a/jarvis/core/__init__.py
+++ b/jarvis/core/__init__.py
@@ -4,6 +4,8 @@ from .system import JarvisSystem
 from .constants import DEFAULT_PORT, LOG_DB_PATH, ExecutionResult
 from .profile import AgentProfile
 from .registry import BaseRegistry, FunctionRegistry
+from .method_recorder_base import MethodRecorderBase
+from .method_recorder import MethodRecorder
 
 __all__ = [
     "JarvisConfig",
@@ -18,4 +20,6 @@ __all__ = [
     "AgentProfile",
     "BaseRegistry",
     "FunctionRegistry",
+    "MethodRecorderBase",
+    "MethodRecorder",
 ]

--- a/jarvis/core/method_recorder.py
+++ b/jarvis/core/method_recorder.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Helpers for recording method invocations into protocols."""
+
+from dataclasses import dataclass
+import uuid
+from typing import Any, Dict
+
+from ..protocols.instruction_protocol import InstructionProtocol
+from ..protocols.models import ProtocolStep
+
+from .method_recorder_base import MethodRecorderBase
+
+
+@dataclass
+class MethodRecorder(MethodRecorderBase):
+    """Record agent capability calls into an :class:`InstructionProtocol`."""
+
+    recording: bool = False
+    protocol: InstructionProtocol | None = None
+
+    def start(self, name: str, description: str = "") -> InstructionProtocol:
+        """Begin a new recording session."""
+        self.protocol = InstructionProtocol(
+            id=str(uuid.uuid4()),
+            name=name,
+            description=description,
+        )
+        self.recording = True
+        return self.protocol
+
+    def record_step(
+        self,
+        agent: str,
+        function: str,
+        params: Dict[str, Any],
+        mappings: Dict[str, str] | None = None,
+    ) -> None:
+        """Append a step to the current protocol."""
+        if not self.recording or not self.protocol:
+            return
+        self.protocol.add_step(agent, function, params, mappings)
+
+    def get_protocol(self) -> InstructionProtocol | None:
+        """Return the current protocol under construction."""
+        return self.protocol
+
+    def replace_step(
+        self,
+        idx: int,
+        agent: str,
+        function: str,
+        params: Dict[str, Any],
+        mappings: Dict[str, str] | None = None,
+    ) -> None:
+        """Replace an existing step at ``idx`` with new parameters."""
+        if not self.protocol:
+            return
+        if idx < 0 or idx >= len(self.protocol.steps):
+            raise IndexError("Step index out of range")
+        self.protocol.steps[idx] = ProtocolStep(
+            agent=agent,
+            function=function,
+            parameters=params,
+            parameter_mappings=mappings or {},
+        )
+
+    def stop(self) -> InstructionProtocol | None:
+        """Finalize recording and return the completed protocol."""
+        proto = self.protocol
+        if proto:
+            self.save(proto)
+        self.protocol = None
+        self.recording = False
+        return proto
+
+    def clear(self) -> None:
+        """Reset recorder state without returning a protocol."""
+        self.protocol = None
+        self.recording = False
+
+    def save(self, protocol: InstructionProtocol) -> None:  # pragma: no cover - override
+        """Persist the completed protocol.
+
+        Default implementation does nothing. Override in subclasses to
+        provide custom persistence.
+        """
+        return None

--- a/jarvis/core/method_recorder_base.py
+++ b/jarvis/core/method_recorder_base.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""Abstract base class for protocol recorders."""
+
+from abc import ABC, abstractmethod
+
+from ..protocols.instruction_protocol import InstructionProtocol
+
+
+class MethodRecorderBase(ABC):
+    """Abstract base for persisting recorded protocols.
+
+    Subclasses must implement :meth:`save` to store completed protocols.
+    """
+
+    @abstractmethod
+    def save(self, protocol: InstructionProtocol) -> None:
+        """Persist the completed protocol."""
+        raise NotImplementedError

--- a/tests/test_method_recorder.py
+++ b/tests/test_method_recorder.py
@@ -1,0 +1,58 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+# Import MethodRecorder without importing jarvis package-level dependencies
+package_path = Path(__file__).resolve().parents[1] / "jarvis"
+core_path = package_path / "core"
+protocols_path = package_path / "protocols"
+
+jarvis_pkg = types.ModuleType("jarvis")
+jarvis_pkg.__path__ = [str(package_path)]
+sys.modules.setdefault("jarvis", jarvis_pkg)
+
+core_pkg = types.ModuleType("jarvis.core")
+core_pkg.__path__ = [str(core_path)]
+sys.modules.setdefault("jarvis.core", core_pkg)
+
+protocols_pkg = types.ModuleType("jarvis.protocols")
+protocols_pkg.__path__ = [str(protocols_path)]
+sys.modules.setdefault("jarvis.protocols", protocols_pkg)
+
+spec = importlib.util.spec_from_file_location(
+    "jarvis.core.method_recorder", core_path / "method_recorder.py"
+)
+module = importlib.util.module_from_spec(spec)
+sys.modules["jarvis.core.method_recorder"] = module
+spec.loader.exec_module(module)
+MethodRecorder = module.MethodRecorder
+
+
+def test_method_recorder_flow():
+    recorder = MethodRecorder()
+    recorder.start("demo", "desc")
+
+    recorder.record_step("agent", "func", {"a": 1})
+    assert recorder.get_protocol() is not None
+    assert len(recorder.get_protocol().steps) == 1
+    assert recorder.get_protocol().steps[0].agent == "agent"
+
+    recorder.replace_step(0, "agent2", "func2", {"b": 2})
+    step = recorder.get_protocol().steps[0]
+    assert step.agent == "agent2"
+    assert step.function == "func2"
+
+    proto = recorder.stop()
+    assert proto is not None
+    assert proto.name == "demo"
+    assert recorder.get_protocol() is None
+    assert recorder.recording is False
+
+
+def test_clear_resets_state():
+    recorder = MethodRecorder()
+    recorder.start("x")
+    recorder.clear()
+    assert recorder.get_protocol() is None
+    assert recorder.recording is False


### PR DESCRIPTION
## Summary
- relocate method recorder utilities from `protocols` to `core`
- split out abstract `MethodRecorderBase` interface
- update exports and tests for new structure

## Testing
- `pytest` *(fails: KeyError: 'jarvis')*
- `pytest tests/test_method_recorder.py`

------
https://chatgpt.com/codex/tasks/task_e_689e9a1c4c10832a88d4c7ee6e2d3043