### PR TITLE
Add network method recording configuration

### DIFF
--- a/jarvis/agents/agent_network.py
+++ b/jarvis/agents/agent_network.py
@@ -12,6 +12,7 @@ from .message import Message
 
 if TYPE_CHECKING:
     from .base import NetworkAgent  # for type hints only
+    from ..core.method_recorder_base import MethodRecorderBase
 
 
 class AgentNetwork:
@@ -21,6 +22,8 @@ class AgentNetwork:
         self,
         logger: Optional[JarvisLogger] = None,
         queue_maxsize: int = 1000,
+        record_methods: bool = False,
+        recorder: "MethodRecorderBase | None" = None,
     ) -> None:
         self.agents: Dict[str, NetworkAgent] = {}
         self.message_queue: asyncio.Queue = asyncio.Queue(maxsize=queue_maxsize)
@@ -41,6 +44,10 @@ class AgentNetwork:
         # Recording state for building instruction protocols
         self.recording: bool = False
         self.current_protocol: InstructionProtocol | None = None
+
+        # Method recording via MethodRecorder
+        self.record_methods = record_methods
+        self.recorder = recorder
 
     def register_agent(
         self,
@@ -201,6 +208,14 @@ class AgentNetwork:
                             mappings = message.content.get("mappings")
                             self.add_instruction(provider, capability, params, mappings)
                     else:
+                        if self.record_methods and self.recorder:
+                            provider = providers[0] if providers else None
+                            if provider:
+                                params = message.content.get("data", {})
+                                mappings = message.content.get("mappings")
+                                self.recorder.record_step(
+                                    provider, capability, params, mappings
+                                )
                         for provider in providers:
                             cloned = Message(
                                 from_agent=message.from_agent,

--- a/jarvis/core/config.py
+++ b/jarvis/core/config.py
@@ -26,6 +26,10 @@ class JarvisConfig:
     response_timeout: float = 15.0
     intent_timeout: float = 5.0
     perf_tracking: bool = True
+    record_network_methods: bool = field(
+        default_factory=lambda: os.getenv("RECORD_NETWORK_METHODS", "false").lower()
+        == "true"
+    )
     memory_dir: Optional[str] = None
     weather_api_key: Optional[str] = None
     hue_bridge_ip: Optional[str] = None

--- a/jarvis/core/system.py
+++ b/jarvis/core/system.py
@@ -20,6 +20,7 @@ from ..night_agents import NightAgent, NightModeControllerAgent
 from ..ai_clients import AIClientFactory, BaseAIClient
 from ..logging import JarvisLogger
 from .config import JarvisConfig
+from .method_recorder import MethodRecorder
 from ..protocols.loggers import ProtocolUsageLogger
 from ..protocols.runtime import ProtocolRuntime
 from ..utils.performance import PerfTracker, get_tracker
@@ -29,15 +30,27 @@ from ..agents.factory import AgentFactory
 class JarvisSystem:
     """Main Jarvis system that manages the agent network."""
 
-    def __init__(self, config: JarvisConfig | Dict[str, Any]):
+    def __init__(
+        self,
+        config: JarvisConfig | Dict[str, Any],
+        record_network_methods: bool = False,
+        method_recorder: MethodRecorder | None = None,
+    ):
         """Create a new Jarvis system."""
         if isinstance(config, dict):
             self.config = JarvisConfig(**config)
         else:
             self.config = config
 
+        if not record_network_methods:
+            record_network_methods = self.config.record_network_methods
+
         self.logger = JarvisLogger()
-        self.network = AgentNetwork(self.logger)
+        self.network = AgentNetwork(
+            self.logger,
+            record_methods=record_network_methods,
+            recorder=method_recorder,
+        )
         self.perf_enabled = self.config.perf_tracking
         self._tracker: PerfTracker | None = None
 


### PR DESCRIPTION
## Summary
- Allow `JarvisConfig` to enable network method recording via the `RECORD_NETWORK_METHODS` environment variable
- Allow `JarvisSystem` to pass recording controls and a `MethodRecorder` to the agent network
- Extend `AgentNetwork` to support method recording and forward capability steps to a recorder

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_689e9cfb2770832a83e1371ebf618fb9