### PR TITLE
Fix method recording interfering with capability responses

### DIFF
--- a/jarvis/agents/agent_network.py
+++ b/jarvis/agents/agent_network.py
@@ -210,7 +210,6 @@ class AgentNetwork:
                             self.method_recorder.record_step(
                                 provider, capability, params, mappings
                             )
-                        continue
 
                     for provider in providers:
                         cloned = Message(
@@ -255,12 +254,6 @@ class AgentNetwork:
         providers = self.capability_registry.get(capability, [])
         if allowed_agents is not None:
             providers = [p for p in providers if p in allowed_agents]
-
-        if self.method_recorder and self.method_recorder.recording:
-            provider = providers[0] if providers else None
-            if provider:
-                self.method_recorder.record_step(provider, capability, data)
-            return providers
 
         # Create and store the Future
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
## Summary
- Ensure capability requests still dispatch while recording methods
- Remove early return that dropped response futures during recording

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_689eadfb4090832aa1053738c4afe19e