### PR TITLE
Skip intent matching step when recording protocols

### DIFF
--- a/jarvis/agents/agent_network.py
+++ b/jarvis/agents/agent_network.py
@@ -202,7 +202,11 @@ class AgentNetwork:
                     allowed = message.content.get("allowed_agents")
                     if allowed:
                         providers = [p for p in providers if p in allowed]
-                    if self.method_recorder and self.method_recorder.recording:
+                    if (
+                        self.method_recorder
+                        and self.method_recorder.recording
+                        and capability != "intent_matching"
+                    ):
                         provider = providers[0] if providers else None
                         if provider:
                             params = message.content.get("data", {})


### PR DESCRIPTION
## Summary
- avoid recording `intent_matching` capability calls so replayed protocols skip the NLU step
- add regression test confirming NLU calls are excluded from recordings

## Testing
- `pytest`
- `pytest tests/test_method_recorder_replay.py::test_intent_matching_not_recorded -q`


------
https://chatgpt.com/codex/tasks/task_e_689eb26eddfc832a89c73a73df5b2ad6